### PR TITLE
Fix support for exporting logs

### DIFF
--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -69,7 +69,9 @@ rec {
           mkdir -p "$out/logs"
           for directory in vm-state-*; do
             name="''${directory#vm-state-}"
-            mv "$directory/xchg/logs" "$out/logs/$name"
+            if [ -d "$directory/xchg/logs" ]; then
+              mv "$directory/xchg/logs" "$out/logs/$name"
+            fi
           done
         ''; # */
     };


### PR DESCRIPTION
The NixOS test log files might not necessarily be present, in
situations like:

* The test finishes before a VM boots up
* A VM is shutdown before the test finishes

To handle those scenarios, we gracefully ignore log
directories that are missing when exporting them to the final
build product.