### PR TITLE
datadog-agent: add option to enable trace agent

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -7,7 +7,7 @@ let
 
   ddConf = {
     dd_url              = "https://app.datadoghq.com";
-    skip_ssl_validation = "no";
+    skip_ssl_validation = false;
     confd_path          = "/etc/datadog-agent/conf.d";
     additional_checksd  = "/etc/datadog-agent/checks.d";
     use_dogstatsd       = true;
@@ -16,6 +16,7 @@ let
   // optionalAttrs (cfg.hostname != null) { inherit (cfg) hostname; }
   // optionalAttrs (cfg.tags != null ) { tags = concatStringsSep ", " cfg.tags; }
   // optionalAttrs (cfg.enableLiveProcessCollection) { process_config = { enabled = "true"; }; }
+  // optionalAttrs (cfg.enableTraceAgent) { apm_config = { enabled = true; }; }
   // cfg.extraConfig;
 
   # Generate Datadog configuration files for each configured checks.
@@ -132,6 +133,15 @@ in {
       default = false;
       type = types.bool;
     };
+
+    enableTraceAgent = mkOption {
+      description = ''
+        Whether to enable the trace agent.
+      '';
+      default = false;
+      type = types.bool;
+    };
+
     checks = mkOption {
       description = ''
         Configuration for all Datadog checks. Keys of this attribute
@@ -244,6 +254,16 @@ in {
           ${pkgs.datadog-process-agent}/bin/agent --config /etc/datadog-agent/datadog.yaml
         '';
       });
+
+      datadog-trace-agent = lib.mkIf cfg.enableTraceAgent (makeService {
+        description = "Datadog Trace Agent";
+        path = [ ];
+        script = ''
+          export DD_API_KEY=$(head -n 1 ${cfg.apiKeyFile})
+          ${pkgs.datadog-trace-agent}/bin/trace-agent -config /etc/datadog-agent/datadog.yaml
+        '';
+      });
+
     };
 
     environment.etc = etcfiles;

--- a/pkgs/tools/networking/dd-agent/datadog-trace-agent-deps.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-trace-agent-deps.nix
@@ -1,0 +1,156 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/DataDog/datadog-agent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/datadog-agent";
+      rev =  "92733ff01547103d5286afc9e272d501cb18f761";
+      sha256 = "1mmb7gyin6c4l6pj0nw3kpmj8wvjm7c8n4h5frv26bhg84m15xhd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/DataDog/datadog-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/datadog-go";
+      rev =  "a9c7a9896c1847c9cc2b068a2ae68e9d74540a5d";
+      sha256 = "1m1vpi2s22dqcq0fqhfp3skzkmsbmhzyiw2kh2dw6ii7qimy8zki";
+    };
+  }
+  {
+    goPackagePath  = "github.com/StackExchange/wmi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/StackExchange/wmi";
+      rev =  "ea383cf3ba6ec950874b8486cd72356d007c768f";
+      sha256 = "1x3a3rdxccrzrnkld67p9ilm086v4w195rdhyw0bq39x1v1vzbln";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cihub/seelog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cihub/seelog";
+      rev =  "d2c6e5aa9fbfdd1c624e140287063c7730654115";
+      sha256 = "0ab9kyrh51x1x71z37pwjsla0qv11a1qv697xafyc4r5nq5hds6p";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev =  "74bdc99692c3408cb103221e38675ce8fda0a718";
+      sha256 = "0ad93rznilmd1hw20nlkr7ywi3sbd299mynf4db20k5yl34r3498";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-ole/go-ole";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ole/go-ole";
+      rev =  "de8695c8edbf8236f30d6e1376e20b198a028d42";
+      sha256 = "084caxl71v8lgg475whj2pz9mij3wk3gpbh3pfyf2dm66b6xrq2k";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev =  "d76fbc1373015ced59b43ac267f28d546b955683";
+      sha256 = "051a3imx2m7gpns8cjm1gckif9z6i4ik0svc1i8j7h86800c5rg0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "1e59b77b52bf8e4b449a57e6f79f21226d571845";
+      sha256 = "19bkh81wnp6njg3931wky6hsnnl2d1ig20vfjxpv450sd3k6yys8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/philhofer/fwd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/philhofer/fwd";
+      rev =  "bb6d471dc95d4fe11e432687f8b70ff496cf3136";
+      sha256 = "1pg84khadh79v42y8sjsdgfb54vw2kzv7hpapxkifgj0yvcp30g2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shirou/gopsutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shirou/gopsutil";
+      rev =  "70a1b78fe69202d93d6718fc9e3a4d6f81edfd58";
+      sha256 = "04qbzj7r7ahq6s407lh9rb3xagbnaj5wp79siq49qkiz3101kfdb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shirou/w32";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shirou/w32";
+      rev =  "bb4de0191aa41b5507caa14b0650cdbddcd9280b";
+      sha256 = "0xh5vqblhr2c3mlaswawx6nipi4rc2x73rbdvlkakmgi0nnl50m4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "12b6f73e6084dad08a7c6e575284b177ecafbc71";
+      sha256 = "01f80s0q64pw5drfgqwwk1wfwwkvd2lhbs56lhhkff4ni83k73fd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tinylib/msgp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tinylib/msgp";
+      rev =  "362bfb3384d53ae4d5dd745983a4d70b6d23628c";
+      sha256 = "0b39cp417ndznkfwdqcbh89f9x3ml4rn7kf4l4als7vqrrwk7vrz";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9";
+      sha256 = "04va4pqygfzr89fx873k44bmivk7nybqalybi6q96lnn45h2scbr";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b";
+      sha256 = "1hj2ag9knxflpjibck0n90jrhsrqz7qvad4qnif7jddyapi9bqzl";
+    };
+  }
+]

--- a/pkgs/tools/networking/dd-agent/datadog-trace-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-trace-agent.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, buildGoPackage  }:
+
+buildGoPackage rec {
+  name = "datadog-trace-agent-${version}";
+  version = "6.5.0";
+  owner   = "DataDog";
+  repo    = "datadog-trace-agent";
+
+  src = fetchFromGitHub {
+    inherit owner repo;
+    rev    = "6.5.0";
+    sha256 = "0xhhcdridilhdwpmr9h3cqg5w4fh87l1jhvzg34k30gdh0g81afw";
+  };
+
+  goDeps = ./datadog-trace-agent-deps.nix;
+  goPackagePath = "github.com/${owner}/${repo}";
+
+  meta = with stdenv.lib; {
+    description = "Live trace collector for the DataDog Agent v6";
+    homepage    = https://www.datadoghq.com;
+    license     = licenses.bsd3;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ rob ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15915,6 +15915,7 @@ with pkgs;
     pythonPackages = datadog-integrations-core {};
   };
   datadog-process-agent = callPackage ../tools/networking/dd-agent/datadog-process-agent.nix { };
+  datadog-trace-agent = callPackage ../tools/networking/dd-agent/datadog-trace-agent.nix { };
   datadog-integrations-core = extras: callPackage ../tools/networking/dd-agent/integrations-core.nix {
     python = python27;
     extraIntegrations = extras;


### PR DESCRIPTION
This is a backport of debbed29d1da582e75ebf266b203baad063550c3
to our fork of 18.09 so that we can keep support for Datadog's application tracing
while using the upstream NixOS module until we upgrade to at least 19.03.