### PR TITLE
apache-airflow: Export PYTHONPATH in wrapper for gunicorn processes

### DIFF
--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -168,6 +168,9 @@ buildPythonPackage rec {
      --replace "/bin/bash" "${stdenv.shell}"
   '';
 
+  # allow for gunicorn processes to have access to python packages
+  makeWrapperArgs = [ "--prefix PYTHONPATH : $PYTHONPATH" ];
+
   checkPhase = ''
    export HOME=$(mktemp -d)
    export AIRFLOW_HOME=$HOME


### PR DESCRIPTION
Backport of e240c5 to `release-20.03`