### PR TITLE
Fix build for `compiler-rt-{5,6}.*.*

### DIFF
--- a/pkgs/development/compilers/llvm/5/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation {
 
   configureFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform.isDarwin) [
+  ];
+
+  cmakeFlags = stdenv.lib.optionals (stdenv.hostPlatform.isDarwin) [
     # The compiler-rt build infrastructure sniffs supported platforms on Darwin
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.

--- a/pkgs/development/compilers/llvm/6/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/6/compiler-rt.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation {
 
   configureFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform.isDarwin) [
+  ];
+
+  cmakeFlags = stdenv.lib.optionals (stdenv.hostPlatform.isDarwin) [
     # The compiler-rt build infrastructure sniffs supported platforms on Darwin
     # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
     # when it tries to use libc++ and libc++api for i386.


### PR DESCRIPTION
I made a mistake when cherry-picking
c3c27f7d36e0eff38e896891d643c4e9d8231b3d
onto the `release-20.03` branch to create
1e5a44e035ed2294e7fef22cdcf9bf966a6a6c00.

Specifically, I accidentally cherry-picked what should have been
a `cmakeFlags` flag as part of the `configureFlags` for some of the
`compiler-rt` builds, which this change fixes.