### PR TITLE
Patch through support for `specialArgs`

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -7,6 +7,7 @@
 , pkgs
 , # NixOS configuration to add to the VMs
   extraConfigurations ? []
+, specialArgs ? {}
 }:
 
 with pkgs.lib;
@@ -31,7 +32,7 @@ rec {
     nodes: configurations:
 
     import ./eval-config.nix {
-      inherit system;
+      inherit system specialArgs;
       modules = configurations ++ extraConfigurations;
       baseModules =  (import ../modules/module-list.nix) ++
         [ ../modules/virtualisation/qemu-vm.nix

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -5,9 +5,11 @@
   # Ignored
 , config ? {}
   # Modules to add to each VM
-, extraConfigurations ? [] }:
+, extraConfigurations ? []
+, specialArgs ? {}
+}:
 
-with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations; };
+with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations specialArgs; };
 with pkgs;
 
 let


### PR DESCRIPTION
This upstreams https://github.com/awakesecurity-dev/end-to-end/blob/d005f355c4b51cf39b54e34ecad89d98c6c7f279/awake-pkgs/nixpkgs/nixos-19_09.patch
into our vendored Nixpkgs.  Doing so greatly simplifies the patch
because we no longer need to thread through a `nixpkgs` argument.

We also never needed to patch `./nixos/default.nix` as we were not
using that file at all.