### PR TITLE
Disable warning for `oneshot` services

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -821,10 +821,6 @@ in
 
   config = {
 
-    warnings = concatLists (mapAttrsToList (name: service:
-      optional (service.serviceConfig.Type or "" == "oneshot" && service.serviceConfig.Restart or "no" != "no")
-        "Service ‘${name}.service’ with ‘Type=oneshot’ must have ‘Restart=no’") cfg.services);
-
     system.build.units = cfg.units;
 
     environment.systemPackages = [ systemd ];


### PR DESCRIPTION
We upgraded `systemd` to handle `Restart=on-failure` for `oneshot`
services, so this warning is inaccurate

This is a forwardport of #6 to the `awake-20.03` branch