### PR TITLE
haskell: Fix with-packages-wrapper MacOS linker hack for GHC 8.8

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -113,7 +113,7 @@ symlinkJoin {
     # Clean up the old links that may have been (transitively) included by
     # symlinkJoin:
     rm -f $dynamicLinksDir/*
-    for d in $(grep dynamic-library-dirs $packageConfDir/*|awk '{print $2}'|sort -u); do
+    for d in $(grep -Poz "dynamic-library-dirs:\s*\K .+\n" $packageConfDir/*|awk '{print $2}'|sort -u); do
       ln -s $d/*.dylib $dynamicLinksDir
     done
     for f in $packageConfDir/*.conf; do
@@ -123,7 +123,7 @@ symlinkJoin {
       # $dynamicLinksDir
       cp $f $f-tmp
       rm $f
-      sed "s,dynamic-library-dirs: .*,dynamic-library-dirs: $dynamicLinksDir," $f-tmp > $f
+      sed "N;s,dynamic-library-dirs:\s*.*,dynamic-library-dirs: $dynamicLinksDir," $f-tmp > $f
       rm $f-tmp
     done
   '') + ''


### PR DESCRIPTION
This cherrypicks 32d2de8e0092864cb0a9dfe68ea67a813e0e600e onto `awake-20.03`

`with-packages-wrapper.nix` has a hack to workaround the linker limit
in MacOS Sierra. However that is now broken with GHC 8.8, because of
slight change in the format of the package config.
In short, the package config produced by GHC 8.8 has a new line between
the key and list of values, while earlier versions have them separated
by a single space.

This PR fixes the linker hack by modifying the `grep` and `sed` commands
to pattern match on either space or new line, so that the hack can work
on all versions of GHC.