### PR TITLE
Remove sri hashes

### DIFF
--- a/pkgs/applications/graphics/fluxus/default.nix
+++ b/pkgs/applications/graphics/fluxus/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     owner = "nebogeo";
     repo = "fluxus";
     rev = "ba9aee218dd4a9cfab914ad78bdb6d59e9a37400";
-    hash = "sha256:0mwghpgq4n1khwlmgscirhmcdhi6x00c08q4idi2zcqz961bbs28";
+    sha256 = "0mwghpgq4n1khwlmgscirhmcdhi6x00c08q4idi2zcqz961bbs28";
   };
 
   buildInputs = [

--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner  = "eXeC64";
     repo   = "imv";
     rev    = "v${version}";
-    sha256 = "sha256:0gk8g178i961nn3bls75a8qpv6wvfvav6hd9lxca1skaikd33zdx";
+    sha256 = "0gk8g178i961nn3bls75a8qpv6wvfvav6hd9lxca1skaikd33zdx";
   };
 
   preBuild = ''

--- a/pkgs/applications/misc/mapproxy/default.nix
+++ b/pkgs/applications/misc/mapproxy/default.nix
@@ -11,7 +11,7 @@ let
         owner = "pyproj4";
         repo = "pyproj";
         rev = "v${version}rel";
-        sha256 = "sha256:18v4h7jx4mcc0x2xy8y7dfjq9bzsyxs8hdb6v67cabvlz2njziqy";
+        sha256 = "18v4h7jx4mcc0x2xy8y7dfjq9bzsyxs8hdb6v67cabvlz2njziqy";
       };
       nativeBuildInputs = with python.pkgs; [ cython ];
       patches = [ ];

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -98,12 +98,12 @@ let
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz";
-      sha256 = "sha256-2Ye1+mhFnkZnAYQXgKZ5YIOiIVaiunTCyCOM+ZExw2I==";
+      sha256 = "0qn3668zk313r3179fm2aqhs50v0g6k805w405kld7j5d3xbb1yr";
     };
 
     i686-linux = fetchurl {
       url = "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz";
-      sha256 = "sha256-B0WGkIt8KDtma/WGyenQ04ctKE7AantUtYnwsjAZZb0=";
+      sha256 = "1gb534qb5w49nma7nsn09ql2v1yks3lwk1pmddk3na3wif88ci87";
     };
   };
 in

--- a/pkgs/applications/networking/cawbird/default.nix
+++ b/pkgs/applications/networking/cawbird/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "IBBoard";
     repo = "cawbird";
     rev = "v${version}";
-    sha256 = "sha256:0zghryx5y47ff8kxa65lvgmy1cnhvhazxml7r1lxixxj3d88wh7p";
+    sha256 = "0zghryx5y47ff8kxa65lvgmy1cnhvhazxml7r1lxixxj3d88wh7p";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/newsreaders/liferea/default.nix
+++ b/pkgs/applications/networking/newsreaders/liferea/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/lwindolf/${pname}/releases/download/v${version}/${pname}-${version}b.tar.bz2";
-    sha256 = "sha256:03pr1gmiv5y0i92bkhcxr8s311ll91chz19wb96jkixx32xav91d";
+    sha256 = "03pr1gmiv5y0i92bkhcxr8s311ll91chz19wb96jkixx32xav91d";
   };
 
   nativeBuildInputs = [ wrapGAppsHook python3Packages.wrapPython intltool pkgconfig ];

--- a/pkgs/applications/window-managers/wmfs/default.nix
+++ b/pkgs/applications/window-managers/wmfs/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "xorg62";
     repo = "wmfs";
-    sha256 = "sha256:1m7dsmmlhq2qipim659cp9aqlriz1cwrrgspl8baa5pncln0gd5c";
+    sha256 = "1m7dsmmlhq2qipim659cp9aqlriz1cwrrgspl8baa5pncln0gd5c";
     rev = "b7b8ff812d28c79cb22a73db2739989996fdc6c2";
   };
 

--- a/pkgs/data/fonts/monoid/default.nix
+++ b/pkgs/data/fonts/monoid/default.nix
@@ -8,13 +8,13 @@ stdenv.mkDerivation {
     owner = "larsenwork";
     repo = "monoid";
     rev = "a331c7c5f402c449f623e0d0895bd2fd8dc30ccf";
-    sha256 = "sha256-RV6lxv5CjywTMcuPMj6rdjLKrap7zLJ7niaNeF//U1Y=";
+    sha256 = "0mjkzxgpi396krxv5k3vmanwlcknmcz353yb649jr3s2zv3aapj5";
   };
 
   patches = [
     (fetchpatch {
       url = "https://github.com/larsenwork/monoid/pull/233/commits/f84f2ed61301ee84dadd16351314394f22ebed2f.patch";
-      sha256 = "sha256-CxfFHlR7TB64pvrfzVfUDkPwuRO2UdGOhXwW98c+oQU=";
+      sha256 = "01d17v3zf5kwhn7d2ldn2fwz0hqfsibwvpzslsw1wk3vahgca5qb";
     })
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-dictionary/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-dictionary/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     # fix AppStream validation
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/gnome-dictionary/commit/1c94d612030ef87c6e26a01a490470b71c39e341.patch";
-      sha256 = "sha256:0cbswmhs9mks3gsc0iy4wnidsa8sfzzf4s1kgvb80qwffgxz5m8b";
+      sha256 = "0cbswmhs9mks3gsc0iy4wnidsa8sfzzf4s1kgvb80qwffgxz5m8b";
     })
   ];
 

--- a/pkgs/desktops/pantheon/apps/appcenter/default.nix
+++ b/pkgs/desktops/pantheon/apps/appcenter/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-8r0DlmG8xlCQ1uFHZQjXG2ls4VBrsRzrVY8Ey3/OYAU=";
+    sha256 = "01b0rrzwn14gapmircbba3hnqs8vsw46aiz1ss851imwc6b07ggj";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-calculator/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calculator/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-ctKUtaBU0qvDYquGCPL7tiTwQ7IcqvT7SXRjxETWXbM=";
+    sha256 = "1csxsr2c8qvl97xz9ahwn91z095nzgr0i1mbcb1spljll2sr9lkj";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-b72BmChl/Ql0ljLRcPMNbJcOV4cVqz5D2j+5BGUi4Go=";
+    sha256 = "0sp049jh9f9zv91kxaqmhxbhx5vc1prp1l9jjrs0kzb552c83gbg";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-camera/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-camera/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-asl5NdSuLItXebxvqGlSEjwWhdButmka12YQAYkQT44=";
+    sha256 = "13jg224h2436swd6kdkfs22icg0ja9lshvxwg5bqnb5fshspkjba";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-code/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-code/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-4AEayj+K/lOW6jEYmvmdan1kTqqqLL1YzwcU7/3PH5U=";
+    sha256 = "158zrzyyy507rxcbsb5am9768zbakpwrl61ixab57zla7z51l0g0";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-GkVnowqGXwnEgplT34Po/BKzC2F/IQE2kIw0SLSLhGU=";
+    sha256 = "0rc4ifs4hd4cj0v028bzc45v64pwx21xylwrhb20jpw61ainfi8s";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-files/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-files/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-wtQW1poX791DAlSFdVV9psnCfBDeVXI2fDZ2GcvvNn8=";
+    sha256 = "0zrnxz5ijxinghv74mfy21yc5jd6gmapb1al091xvvqpkbb1dm62";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-music/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-music/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-3GZoBCu9rF+BnNk9APBzKWO1JYg1XYWwrEvwcjWvYDE=";
+    sha256 = "0cb0mwsp5w2bmjq8ap9mi0jvaqr9fgq00gfrkj0mzb5x5c26hrnw";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-bTk4shryAWWMrKX3mza6xQ05qpBPf80Ey7fmYgKLUiY=";
+    sha256 = "09jjic165rmprc2cszsgj2m3j3f5p8v9pxx5mj66a0gj3ar3hfbd";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-screenshot-tool/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-screenshot-tool/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-qo55fzp0ieYF5I5uxnCQY066mege06InHL3B3ahYMZ0=";
+    sha256 = "179ib2ldvhdx3hks5lqyx2cvlkk3j1qccvlfwh2yd2bl79zpk3ma";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-giVmL0zYEVYJ40ZBQ9dDb4hOx4HaYRt7tUTOu37lMYU=";
+    sha256 = "119iwmzbpkj4nmxinqfsh73lx23g8gbl6ha6wc4mc4fq9hpnc9c2";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-videos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-videos/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-MSyhCXsziQ0MD4lGp9X/9odidjT/L+2Aihwd1qCGvB0=";
+    sha256 = "07dwhshdc78wia0fsbzz6iv651znzzasfil91w60v29kgc4s2b1i";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/sideload/default.nix
+++ b/pkgs/desktops/pantheon/apps/sideload/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-eI/j6+lok9axRHV5DCsFY1fDCV+X5zBR7X8rK6odjFY=";
+    sha256 = "0mlc3nm2navzxm8k1rwpbw4w6mv30lmhqybm8jqxd4v8x7my73vq";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-3PaOIadlEdYvfNZJaoAQVDKdSTfUdn+snCa8tHmDFD0=";
+    sha256 = "0g8lhdwv9g16kjn7yxnl6x4rscjl2206ljfnghpxc4b5lwhqxxnw";
   };
 
   patches = [

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-wis6wNEOOjPLUCT9vRRhMxbKHR2Y2nZArKogSF/FQv8=";
+    sha256 = "1zs2qmglh85ami07dnlq3lfwl5ikc4abvz94a35k6fhfs703lay2";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-uiu19XyogNR0LX/2IIZM6B1JKAfqDMOHniQ29EAa9XM=";
+    sha256 = "0wzm390g8di4ks3w637a0wl4j7g89j321xkz5msd9058gksvaaxs";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-avu9Hya3C9g8kGl3D9bLwuZBkNPdwyvLspuBWgvpXU8=";
+    sha256 = "0ksxx45mm0cvnb5jphyxsf843rn2rgb0yxv9j0ydh2xp4qgvvyva";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-qgsU3NXqH7ryUah7rEnUrsbecV4AsOo4QfgTcWc5bc4=";
+    sha256 = "1kkd75kp24zq84wfmc00brqxximfsi4sqyx8a7rbl7zaspf182xa";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-mjmvuSipCRGg/HSa1n1eLyVU1gERNT2ciqgz/0KqX0Y=";
+    sha256 = "0ijzm91gycx8iaf3sd8i07b5899gbryxd6klzjh122d952wsyfcs";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-iuv5NZ7v+rXyFsKB/PvGa/7hm9MIV8E6JnTzEGROlhM=";
+    sha256 = "04wn9rj11wvl4qxc2mq8sfdy3zkbqvxzr0f22vrbbypgkqszkswa";
   };
 
   patches = [

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-WJ/GRhZsSwC31HEIjHHWBy9/Skqbwor0tNVTedue3kk=";
+    sha256 = "0jfykvdpjlymnks8mhlv9957ybq7srqqq23isjvh0jvc2r3cd7sq";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-PYgewxBblhOfOJQSeRaq8xD7qZ3083EvgUjpi92FqyI=";
+    sha256 = "08mbhpfqpsa8h4pp3wzlknlzn47km8b7j4ll72gi75jv231ix21x";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-MBCSQ+4l0mpS2OTDRJ7+91qo0SWm5nJNYO7SZaSoVQk=";
+    sha256 = "02amm2j6blpfc16p5rm64p8shnppzsg49hz4v196mli5xr1r441h";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-CVYKcRty5bBEMNyoY51JAJQy6uh+U+7IvS6V/1GMCA4=";
+    sha256 = "03h8ii8zz59fpp4fwlvyx3m3550096fn7a6w612b1rbj3dqhlmh9";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-CHl+4mVjrDg2gusrWOCfI++DZMWKLdvHxG3ZWMjZ2to=";
+    sha256 = "1nnsv745inbdqk3xnbcaqmj87vr3kzh5hazbh8v3ib33cpi7wy88";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-swcbkaHHe9BZxMWvjdRutvYfXXrSCUJWuld1btfYeH0=";
+    sha256 = "0zbqv3bnwxapp9b442fjg9fizxmndva8vby5qicx0yy7l68in1xk";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-tnAJyyPN/Xy1pmlgBpgO2Eb5CeHrRltjQTHmuTPBt8s=";
+    sha256 = "1jxpq4rvkrii85imnipbw44zjinq1sc0cq39lssprzfd4g5hjw5n";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Sws6FqUL7QAROInDrcqYAp6j1TCC4aGV0/hi5Kmm5wQ=";
+    sha256 = "0177lsly8qpqsfas3qc263as77h2k35avhw9708h1v8bllb3l2sb";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-/M60w14zfAUXspabvTUWlOPRrHvKtCYUio82b034k6s=";
+    sha256 = "1awkz16nydlgi8a2dd6agfnd3qwl2qsvv6wnn8bhaz1kbv1v9kpw";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ITgxLZSB4zhSaFKX7Vbf89DGI8ibIcGEQTtLjcGN2tA=";
+    sha256 = "1l6sip0qsjrv862c28cvr0iwdl7kvxbfv5sjd193iqw1jhnk2f11";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-N3WZysLIah40kcyIyhryZpm2FxCmlvp0EB1krZ/IsYs=";
+    sha256 = "12xir2gssr0x21sgm5m620bvd6b6y8dcm26cj4s1wsn8qb59jx9p";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-eE0/LLdnpxOpBvdpioGKV/DOQ5lIuQt9dPnhGkQDGCs=";
+    sha256 = "0aqq0d21mqgrfiyhpfa8k51wxw2pia0qlsgp0sli79v7nwn3ykbq";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-6XFzjpuHpGIZ+azkPuFcSF7p66sDonwLwjvlNBZDRmc=";
+    sha256 = "0rs68cb39r9vq85pr8h3mgmyjpj8bkhkxr5cz4cn5947kf776wg9";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/artwork/elementary-sound-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-sound-theme/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-v8ludbPCJaMHCxuzjZchTJwpGiF6UJlVMIMFg+lAhbU=";
+    sha256 = "1dc583lq61c361arjl3s44d2k72c46bqvcqv1c3s69f2ndsnxjdz";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/artwork/elementary-wallpapers/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-wallpapers/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-Q5sYDXqFhiTu8nABmyND3L8bIXd1BJ3GZQ9TL3SzwzA=";
+    sha256 = "0c63nds2ylqgcp39s13mfwhipgyw8cirn0bhybp291l5g86ii6s3";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-HKrDs2frEWVPpwyGNP+NikrjyplSXJj1hFMLy6kK4wM=";
+    sha256 = "00z31alwn2skhksrhp2jk75f6jlaipzk91hclx7na4gbcyrw7ahw";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-Enn+ekALWbk7FVJJuea/rNiwEZDIyb3kyMcZNNraOv8=";
+    sha256 = "1zrsvbd386f7r3jbvjf8j08v1n5cpzkbjjaj2lxvjn8b81xgwy8j";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-tLTwXA2miHqYqCUbIiBjb2nQB+uN/WzuE4F9m3fVCbM=";
+    sha256 = "1cq9smvrnzc12gp6rzcdxc3x0sbgcch246r5m2c7m2561mfg1d5l";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/elementary-print-shim/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-print-shim/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-l2IUu9Mj22lZ5yajPcsGrJcJDakNu4srCV0Qea5ybPA=";
+    sha256 = "1w3cfap7j42x14mqpfqdm46hk5xc0v5kv8r6wxcnknr3sfxi8qlp";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-TFS29vwDkTtoFcIVAbKskyLemqW9fxE7fQkM61DpDm0=";
+    sha256 = "0v8fx58fn309glxi2zxxlnddw8lkmjr025f22ml3p483zkvbcm2c";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/gala/default.nix
+++ b/pkgs/desktops/pantheon/desktop/gala/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-BOarHUEgWqQM6jmVMauJi0JnsM+jE45MnPNnAqz1qOE=";
+    sha256 = "1qd8ynn04rzkki68w4x3ryq6fhlbi6mk359rx86a8ni084fsprh4";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-NeazBzkbdQTC6OzPxxyED4OstMkNkUGtCIaZD67fTnM=";
+    sha256 = "0wsfvyp0z6c612nl348dr6sar0qghhfcgkzcx3108x8v743v7rim";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-txEjChutJCse/WjgQEfo+MSeeGWdpHUABGCsAqK6i3o=";
+    sha256 = "0ylbpai05b300h07b94xcmw9xi7qx13l1q38zlg2n95d3c5264dp";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-rZzZIh4bwZfwQFDbfPDKQtfLMJQ2IdykH1yiV6ckqnw=";
+    sha256 = "0z5a4jkmg8jw3yjdq89njhqcpms2rbq7rnsh83q9gh8v3qidk75d";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-/sTx0qT7gNj1waQg9OKqHY6MtL+p0NljiIAXKA3DYmA=";
+    sha256 = "0q32qc6jh5w0i1ixkl59pys8r3hxmbig8854q7sxi07vlk9g3i7y";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-wVHvHduUT55rIWRfRWg3Z3jL3FdzUJfiqFONRmpCR8k=";
+    sha256 = "1ja789m4d3akm3i9fl3kazfcny376xl4apv445mrwkwlvcfyylf1";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-0f03XO74ezzS/Uy0mXT4raoazETL/SOVh58sAo9bEIA=";
+    sha256 = "100hbf7h4b4zhyaj7zfb8k61mamdz1s9kd2czp93qyzqxrf3gzfi";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-tVPSJO/9IXlibLkb6Cv+8azdvuXbcNOI1qYk4VQc4WI=";
+    sha256 = "0qp13iaf2956ss4d6w6vwnzdvb7izqmyh6xrdii7j8gxxwjd4lxm";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-wjYZXFnzvPSukzh1BNvyaFxKpYm+kNNFm5AsthLXGVE=";
+    sha256 = "0l8rsw9bcb4hkd2x745yi6jllp38ybdh8x9qjfpg9g7kb5f1jdn2";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-iBbYOeGlv2lUFSK1qcd+4UJlCP/KCtdkx6i73jq6Ngo=";
+    sha256 = "02inp8xdxfx8qxjdf2nazw46ahp1gv3skd922ma6kgx5w4wxh5l8";
   };
 
   patches = [

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-WGkxLsbdJ7Z7kolymYpggsVy4cN4CicNKdfCbunklSI=";
+    sha256 = "08lmwklnxhnp546jf2kqqghp5ic2c259jwl9j9xvc9yxqqp32saq";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-mXi600gufUK81Uks9p4+al0tCI7H9KpizZGyoomp42s=";
+    sha256 = "0sz3m64s5clirmiamx67iq42spba7sggcb29sny44z9f939vly4r";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/granite/default.nix
+++ b/pkgs/desktops/pantheon/granite/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ytbjuo9RnYyJ9+LqtWE117dGlNErLl+nmTM22xGGDo8=";
+    sha256 = "13qfhq8xndikk6kmybibs6a4ddyp6mhvbsp2yy4qr7aiiyxf7mna";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/services/contractor/default.nix
+++ b/pkgs/desktops/pantheon/services/contractor/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-FHLecRxTE8v3M7cV6rkQKNhPhKFhuhvkzB5C+u7Z+Ms=";
+    sha256 = "1jzqv7pglhhyrkj1pfk1l624zn1822wyl5dp6gvwn4sk3iqxwwhl";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/services/elementary-capnet-assist/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-capnet-assist/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-o6J3vNWvV0zRde8VWWfpb56PQhSck2sJQVLimq0P9CY=";
+    sha256 = "09pl1ynrmqjj844np4ww2i18z7kgx5kmj5ggfp8lqmxgsny7g8m3";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/services/elementary-dpms-helper/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-dpms-helper/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-0KbfAxvZ+aFjq+XEK4uoRHSyKlaky0FlJd2a5TG4bms=";
+    sha256 = "0svfp0qyb6nx4mjl3jx4aqmb4x24m25jpi75mdis3yfr3c1xz9nh";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/services/pantheon-agent-geoclue2/default.nix
+++ b/pkgs/desktops/pantheon/services/pantheon-agent-geoclue2/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-LrDu9NczSKN9YLo922MqYbcHG1QAwzXUb7W0Q/g9ftI=";
+    sha256 = "1lky7pw47d5mdza3bhq0ahdhgdv159ixngdsc1ys6j1kszsfxc1f";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/services/pantheon-agent-polkit/default.nix
+++ b/pkgs/desktops/pantheon/services/pantheon-agent-polkit/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-YL1LHnPH7pP0EW9IkjdSEX+VuaAF9uNyFbl47vjVps0=";
+    sha256 = "1kd6spwfwy5r2mrf7xh5l2wrazqia8vr4j3g27s97vn7fcg4pgb0";
   };
 
   passthru = {

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner  = "ximion";
     repo   = "appstream";
     rev    = "v${version}";
-    sha256 = "sha256-bCDyMwQdn9Csxs2hy4dm+LjtxK4+YBK6yDkAdhu1QVU=";
+    sha256 = "0ma1nldpc01rr2x14q1ymv2fvf7qcs3wp8fdqsnd17qx0hrz483c";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/civetweb/default.nix
+++ b/pkgs/development/libraries/civetweb/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256:1drnid6gs97cp9zpvsxz42yfj8djmgx98fg9p2993x9mpi547vzv";
+    sha256 = "1drnid6gs97cp9zpvsxz42yfj8djmgx98fg9p2993x9mpi547vzv";
   };
 
   makeFlags = [

--- a/pkgs/development/libraries/libuninameslist/default.nix
+++ b/pkgs/development/libraries/libuninameslist/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "fontforge";
     repo = pname;
     rev = version;
-    sha256 = "sha256:034c8clnskvqbwyiq7si4dad1kbngi3jmnrj064i39msqixmpdzb";
+    sha256 = "034c8clnskvqbwyiq7si4dad1kbngi3jmnrj064i39msqixmpdzb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/multipart-parser-c/default.nix
+++ b/pkgs/development/libraries/multipart-parser-c/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "iafonov";
     repo = pname;
     rev = "772639cf10db6d9f5a655ee9b7eb20b815fab396";
-    sha256 = "sha256:056r63vj8f1rwf3wk7jmwhm8ba25l6h1gs6jnkh0schbwcvi56xl";
+    sha256 = "056r63vj8f1rwf3wk7jmwhm8ba25l6h1gs6jnkh0schbwcvi56xl";
   };
 
   buildPhase = ''

--- a/pkgs/development/libraries/speechd/default.nix
+++ b/pkgs/development/libraries/speechd/default.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/brailcom/speechd/releases/download/${version}/${pname}-${version}.tar.gz";
-    hash = "sha256:16bg52hnkrsrs7kgbzanb34b9zb6fqxwj0a9bmsxmj1skkil1h1p";
+    sha256 = "16bg52hnkrsrs7kgbzanb34b9zb6fqxwj0a9bmsxmj1skkil1h1p";
   };
 
   patches = [

--- a/pkgs/development/libraries/ticpp/default.nix
+++ b/pkgs/development/libraries/ticpp/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     owner = "wxFormBuilder";
     repo = "ticpp";
     rev = "eb79120ea16b847ce9f483a298a394050f463d6b";
-    sha256 = "sha256:0xk4cy0xbkr6326cqd1vd6b2x0rfsx4iz2sq8f5jz3yl3slxgjm2";
+    sha256 = "0xk4cy0xbkr6326cqd1vd6b2x0rfsx4iz2sq8f5jz3yl3slxgjm2";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     owner = "pazz";
     repo = "alot";
     rev = version;
-    sha256 = "sha256-WUwOJcq8JE7YO8sFeZwYikCRhpufO0pL6MKu54ZYsHI=";
+    sha256 = "0wmhb23fgbn2x15llfwzkf392h4a32f7j1fb7gc4w95wr8jhwk2r";
   };
 
   patches = [

--- a/pkgs/development/python-modules/django-simple-captcha/default.nix
+++ b/pkgs/development/python-modules/django-simple-captcha/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256:1g92sdgcb81r3il34pg0z210cz6wm14k00b558nshai8br1g09gw";
+    sha256 = "1g92sdgcb81r3il34pg0z210cz6wm14k00b558nshai8br1g09gw";
     extension = "zip";
   };
 

--- a/pkgs/development/python-modules/fritzconnection/default.nix
+++ b/pkgs/development/python-modules/fritzconnection/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
     owner = "kbr";
     repo = pname;
     rev = version;
-    hash = "sha256:17z4shs56ci9mxmilppv5xy9gbnbp6p1h2ms6x55nkvwndacrp7x";
+    sha256 = "17z4shs56ci9mxmilppv5xy9gbnbp6p1h2ms6x55nkvwndacrp7x";
   };
 
   disabled = pythonOlder "3.5";

--- a/pkgs/development/python-modules/imgaug/default.nix
+++ b/pkgs/development/python-modules/imgaug/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "https://github.com/aleju/imgaug/archive/c3d99a420efc45652a1264920dc20378a54b1325.zip";
-    sha256 = "sha256:174nvhyhdn3vz0i34rqmkn26840j3mnfr55cvv5bdf9l4y9bbjq2";
+    sha256 = "174nvhyhdn3vz0i34rqmkn26840j3mnfr55cvv5bdf9l4y9bbjq2";
   };
 
   postPatch = ''

--- a/pkgs/development/tools/ofono-phonesim/default.nix
+++ b/pkgs/development/tools/ofono-phonesim/default.nix
@@ -13,7 +13,7 @@ mkDerivation {
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/network/ofono/phonesim.git";
     rev = "adf231a84cd3708b825dc82c56e841dd7e3b4541";
-    sha256 = "sha256:1840914sz46l8h2jwa0lymw6dvgj72wq9bhp3k4v4rk6masbf6hp";
+    sha256 = "1840914sz46l8h2jwa0lymw6dvgj72wq9bhp3k4v4rk6masbf6hp";
   };
 
   nativeBuildInputs = [

--- a/pkgs/games/pingus/default.nix
+++ b/pkgs/games/pingus/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://gitlab.com/pingus/pingus/";
     rev = "709546d9b9c4d6d5f45fc9112b45ac10c7f9417d";
-    sha256 = "sha256:11mmzk0766riaw5qyd1r5i7s7vczbbzfccm92bvgrm99iy1sj022";
+    sha256 = "11mmzk0766riaw5qyd1r5i7s7vczbbzfccm92bvgrm99iy1sj022";
     fetchSubmodules = true;
   };
 

--- a/pkgs/misc/tpm2-pkcs11/default.nix
+++ b/pkgs/misc/tpm2-pkcs11/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "tpm2-software";
     repo = pname;
     rev = version;
-    sha256 = "sha256:06kpf730al50xv1q53ahycky3im23ysrqp40libls4k24zxs9ha2";
+    sha256 = "06kpf730al50xv1q53ahycky3im23ysrqp40libls4k24zxs9ha2";
   };
 
   patches = lib.singleton (

--- a/pkgs/servers/matterbridge/default.nix
+++ b/pkgs/servers/matterbridge/default.nix
@@ -5,11 +5,11 @@ buildGoModule rec {
   version = "1.16.3";
 
   goPackagePath = "github.com/42wim/matterbridge";
-  modSha256 = "sha256-Q6R6AhAELirFijw5ntyjly46HCzFMpLGSJYfv864gt0=";
+  modSha256 = "1pc2p37by7wn93394cn55hf3lblplgf9wf9wib2jlbh42017m923";
 
   src = fetchurl {
     url = "https://github.com/42wim/matterbridge/archive/v${version}.tar.gz";
-    sha256 = "sha256-VAbZSXilmmd2z2bK4/UZzOrjohDVcJHah9t3DE1mtOE=";
+    sha256 = "1qdlcr6hqxyvhzd92w6m22if7snc37sy7jk6rxv6g6m5g14xj1jl";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -11,11 +11,11 @@
     inherit (localSystem) system;
     inherit sha256 executable;
   }; in {
-    sh      = fetch { file = "sh";    sha256 = "sha256-nbb4XEk3go7ttiWrQyKQMLzPr+qUnwnHkWMtVCZsMCs="; };
-    bzip2   = fetch { file = "bzip2"; sha256 = "sha256-ybnA+JWrKhXSfn20+GVKXkHFTp2Zt79hat8hAVmsUOc="; };
-    mkdir   = fetch { file = "mkdir"; sha256 = "sha256-nmvMxmfcY41/60Z/E8L9u0vgePW5l30Dqw1z+Nr02Hk="; };
-    cpio    = fetch { file = "cpio";  sha256 = "sha256-cB36rN3NLj19Tk37Kc5bodMFMO+mCpEQkKKo0AEMkaU="; };
-    tarball = fetch { file = "bootstrap-tools.cpio.bz2"; sha256 = "sha256-kh2vKmjCr/HvR06czZbxUxV5KDRxSF27M6nN3cyofRI="; executable = false; };
+    sh      = fetch { file = "sh";    sha256 = "0arhdhk58bb3j73hk7wlxapwzg1hj0i47ar5nvnqx0ip95fgidlx"; };
+    bzip2   = fetch { file = "bzip2"; sha256 = "1rshmich28fzd9hvzdwrkm7cahay99jzid3xgv91aambjpwc1ff9"; };
+    mkdir   = fetch { file = "mkdir"; sha256 = "0yfqykdghwqdmc1pv5xrymwf0jxvzp116zs6xdzqsqywcz3cqswy"; };
+    cpio    = fetch { file = "cpio";  sha256 = "19ci1h0x1a52j08922m6xwq0blx1bg72kysd9ryksbndvnngl7bh"; };
+    tarball = fetch { file = "bootstrap-tools.cpio.bz2"; sha256 = "04kxm36dvkd96fxmsj3i6hl7j5aky6bcv72f8zpz3by2d0may7cj"; executable = false; };
   }
 }:
 

--- a/pkgs/tools/admin/aws-rotate-key/default.nix
+++ b/pkgs/tools/admin/aws-rotate-key/default.nix
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "Fullscreen";
     repo = "aws-rotate-key";
-    sha256 = "sha256:1w9704g1l2b0y6g6mk79g28kk0yaswpgljkk85d0i10wyxq4icby";
+    sha256 = "1w9704g1l2b0y6g6mk79g28kk0yaswpgljkk85d0i10wyxq4icby";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/misc/h/default.nix
+++ b/pkgs/tools/misc/h/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "zimbatm";
     repo = "h";
     rev = "v${version}";
-    hash = "sha256-chGrMtvLyyNtlM7PO1olVdkzkvMOk6OibHw+mqwVxIM=";
+    sha256 = "10y42nn9lgkwdjia74qfyf937nam4md3pkyfjinj7jybvcran4bj";
   };
 
   buildInputs = [ ruby ];

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -192,7 +192,7 @@ in rec {
       owner = "NixOS";
       repo = "nix";
       rev = "f15651303f8596bf34c67fc8d536b1e9e7843a87";
-      hash = "sha256-HqM3Z4DLdMrf+0PPZL9ysctGg+K+i3S/IHA1GsJj0Ro=";
+      sha256 = "06nicg11ldbh42zp92xywa1ldjxifazn9ks3zggwlx6bh1kkg8qy";
     };
 
     inherit storeDir stateDir confDir boehmgc;

--- a/pkgs/tools/security/gnupg-pkcs11-scd/default.nix
+++ b/pkgs/tools/security/gnupg-pkcs11-scd/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/alonbl/${pname}/releases/download/${pname}-${version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256:1mfh9zjbahjd788rq1mzx009pd7p1sq62sbz586rd7szif7pkpgx";
+    sha256 = "1mfh9zjbahjd788rq1mzx009pd7p1sq62sbz586rd7szif7pkpgx";
   };
 
   buildInputs = [ pkcs11helper pkgconfig openssl ];

--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "OpenSC";
     repo = "OpenSC";
     rev = version;
-    sha256 = "sha256-OjOfA1pIu8NeN+hPuow5UVMKsg0PrsLojw5h05/Qm+o=";
+    sha256 = "1slvs2gx6q8fizlc5bhg1nr0llsi766blkz86xgc7fs8b81rycrs";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
The motivation for this change is to support Nix 2.1.3.  In theory
Nixpkgs 20.03 should have supported Nix 2.1.3 (according to
`./lib/minver.nix`), but in practice it did not:

https://github.com/NixOS/nixpkgs/issues/89275

However, this was fixed in:

https://github.com/NixOS/nixpkgs/pull/89308

… and this change manually backports that to the `awake-20.03` branch.  The
above change could not be cherry-picked due to merge conflicts with frequently
changing hashes.