### PR TITLE
Support Nix 2.0.4

### DIFF
--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -4,6 +4,7 @@
 , hiredis
 , iptables
 , jdk
+, lib
 , libatasmart
 , libdbi
 , libgcrypt
@@ -339,9 +340,9 @@ let
 
   buildInputs =
     if enabledPlugins == null
-    then builtins.concatMap pluginBuildInputs
+    then lib.concatMap pluginBuildInputs
       (builtins.attrNames plugins)
-    else builtins.concatMap pluginBuildInputs enabledPlugins;
+    else lib.concatMap pluginBuildInputs enabledPlugins;
 in {
   inherit configureFlags buildInputs;
 }


### PR DESCRIPTION
The `release-20.03` branch claims to support Nix version 2.0 or greater
in `./lib/minver.nix`, but at least one place uses `builtins.concatMap`,
which is not present in Nix 2.0.4.

This fixes that by using `lib.concatMap`, which will fall back to
`builtins.concatMap` if it is present.