### PR TITLE
Patch in `specialArgs` to Python test driver

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -5,9 +5,11 @@
   # Ignored
 , config ? {}
   # Modules to add to each VM
-, extraConfigurations ? [] }:
+, extraConfigurations ? []
+, specialArgs ? {}
+}:
 
-with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations; };
+with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations specialArgs; };
 with pkgs;
 
 let


### PR DESCRIPTION
Applies the change Gabriel introduced in <https://github.com/awakesecurity/nixpkgs/commit/69d1771fb09f9704717bdc1a2fd2d66b93f3d48d> to the Python test driver.