### PR TITLE
nixos/config: add defaultPackages option

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -43,6 +43,12 @@ let
       pkgs.which # 88K size
     ];
 
+    defaultPackages = map (pkg: setPrio ((pkg.meta.priority or 5) + 3) pkg)
+      [ pkgs.perl
+        pkgs.rsync
+        pkgs.strace
+      ];
+
 in
 
 {
@@ -62,6 +68,21 @@ in
           configuration.  (The latter is the main difference with
           installing them in the default profile,
           <filename>/nix/var/nix/profiles/default</filename>.
+        '';
+      };
+
+      defaultPackages = mkOption {
+        type = types.listOf types.package;
+        default = defaultPackages;
+        example = literalExample "[]";
+        description = ''
+          Set of packages users expect from a minimal linux istall.
+          Like systemPackages, they appear in
+          /run/current-system/sw.  These packages are
+          automatically available to all users, and are
+          automatically updated every time you rebuild the system
+          configuration.
+          If you want a more minimal system, set it to an empty list.
         '';
       };
 
@@ -104,7 +125,7 @@ in
 
   config = {
 
-    environment.systemPackages = requiredPackages;
+    environment.systemPackages = requiredPackages ++ config.environment.defaultPackages;
 
     environment.pathsToLink =
       [ "/bin"


### PR DESCRIPTION
readd perl (used in shell scripts), rsync (needed for NixOps) and strace (common debugging tool)

they where previously removed in https://github.com/NixOS/nixpkgs/pull/91213

Co-authored-by: Timo Kaufmann <timokau@zoho.com>
Co-authored-by: 8573 <8573@users.noreply.github.com>