### PR TITLE
Backport `shell_interact` method for NixOS driver

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -21,6 +21,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import telnetlib
 import tempfile
 import time
 import traceback
@@ -454,6 +455,15 @@ class Machine:
                 status_code = int(match[2])
                 return (status_code, output)
             output += chunk
+
+    def shell_interact(self) -> None:
+        """Allows you to interact with the guest shell
+
+        Should only be used during testing, not in the production test."""
+        self.connect()
+        telnet = telnetlib.Telnet()
+        telnet.sock = self.shell  # type: ignore
+        telnet.interact()
 
     def succeed(self, *commands: str) -> str:
         """Execute each command and check that it succeeds."""

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -462,9 +462,10 @@ class Machine:
         Should only be used during testing, not in the production test."""
         self.connect()
         self.log("Terminal is ready (there is no prompt):")
-        telnet = telnetlib.Telnet()
-        telnet.sock = self.shell  # type: ignore
-        telnet.interact()
+        subprocess.run(
+            ["socat", "READLINE", f"FD:{self.shell.fileno()}"],
+            pass_fds=[self.shell.fileno()],
+        )
 
     def succeed(self, *commands: str) -> str:
         """Execute each command and check that it succeeds."""

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -461,6 +461,7 @@ class Machine:
 
         Should only be used during testing, not in the production test."""
         self.connect()
+        self.log("Terminal is ready (there is no prompt):")
         telnet = telnetlib.Telnet()
         telnet.sock = self.shell  # type: ignore
         telnet.interact()

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -47,7 +47,7 @@ rec {
         # TODO: copy user script part into this file (append)
 
         wrapProgram $out/bin/nixos-test-driver \
-          --prefix PATH : "${lib.makeBinPath [ qemu_test vde2 netpbm coreutils ]}" \
+          --prefix PATH : "${lib.makeBinPath [ qemu_test vde2 netpbm coreutils socat ]}" \
       '';
   };
 


### PR DESCRIPTION
This allows the user to log into a machine from the NixOS interactive test driver by running `machine.shell_interact()`

This is the same as #20, except backported to `awake-20.09`