### PR TITLE
nixos/tmp: Make /tmp on ramdisk usable again

### DIFF
--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -30,7 +30,13 @@ with lib;
 
   config = {
 
-    systemd.additionalUpstreamSystemUnits = optional config.boot.tmpOnTmpfs "tmp.mount";
+    systemd.mounts = mkIf config.boot.tmpOnTmpfs [
+      {
+        what = "tmpfs";
+        where = "/tmp";
+        mountConfig.Options = [ "mode=1777" "strictatime" "rw" "nosuid" "nodev" "size=50%" ];
+      }
+    ];
 
     systemd.tmpfiles.rules = optional config.boot.cleanTmpDir "D! /tmp 1777 root root";
 


### PR DESCRIPTION
Backport of 56d7e7492cbf2d61bd570f5b0a8015040e80aae9 to `awake-20.09`