### PR TITLE
Backport GHC 9.2.1 to awake-20.09.

### DIFF
--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -1,0 +1,303 @@
+{ lib, stdenv, pkgsBuildTarget, targetPackages
+
+# build-tools
+, bootPkgs
+, autoconf, automake, coreutils, fetchpatch, fetchurl, perl, python3, m4, sphinx, xattr
+, bash
+
+, libiconv ? null, ncurses
+, glibcLocales ? null
+
+, # GHC can be built with system libffi or a bundled one.
+  libffi ? null
+
+, useLLVM ? !(stdenv.targetPlatform.isx86
+              || stdenv.targetPlatform.isPowerPC
+              || stdenv.targetPlatform.isSparc
+              || (stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin))
+, # LLVM is conceptually a run-time-only depedendency, but for
+  # non-x86, we need LLVM to bootstrap later stages, so it becomes a
+  # build-time dependency too.
+  buildLlvmPackages, llvmPackages
+
+, # If enabled, GHC will be built with the GPL-free but slightly slower native
+  # bignum backend instead of the faster but GPLed gmp backend.
+  enableNativeBignum ? !(lib.any (lib.meta.platformMatch stdenv.hostPlatform) gmp.meta.platforms)
+, gmp
+
+, # If enabled, use -fPIC when compiling static libs.
+  enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
+
+  # aarch64 outputs otherwise exceed 2GB limit
+, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+
+, # Whether to build dynamic libs for the standard library (on the target
+  # platform). Static libs are always built.
+  enableShared ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.useiOSPrebuilt
+
+, # Whether to build terminfo.
+  enableTerminfo ? !stdenv.targetPlatform.isWindows
+
+, # What flavour to build. An empty string indicates no
+  # specific flavour and falls back to ghc default values.
+  ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
+    (if useLLVM then "perf-cross" else "perf-cross-ncg")
+
+, # Whether to disable the large address space allocator
+  # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+  disableLargeAddressSpace ? stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64
+}:
+
+assert !enableNativeBignum -> gmp != null;
+
+let
+  inherit (stdenv) buildPlatform hostPlatform targetPlatform;
+
+  inherit (bootPkgs) ghc;
+
+  # TODO(@Ericson2314) Make unconditional
+  targetPrefix = lib.optionalString
+    (targetPlatform != hostPlatform)
+    "${targetPlatform.config}-";
+
+  buildMK = ''
+    BuildFlavour = ${ghcFlavour}
+    ifneq \"\$(BuildFlavour)\" \"\"
+    include mk/flavours/\$(BuildFlavour).mk
+    endif
+    DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
+    BIGNUM_BACKEND = ${if enableNativeBignum then "native" else "gmp"}
+  '' + lib.optionalString (targetPlatform != hostPlatform) ''
+    Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
+    CrossCompilePrefix = ${targetPrefix}
+    HADDOCK_DOCS = NO
+    BUILD_SPHINX_HTML = NO
+    BUILD_SPHINX_PDF = NO
+  '' + lib.optionalString (!enableProfiledLibs) ''
+    GhcLibWays = "v dyn"
+  '' + lib.optionalString enableRelocatedStaticLibs ''
+    GhcLibHcOpts += -fPIC
+    GhcRtsHcOpts += -fPIC
+  '' + lib.optionalString targetPlatform.useAndroidPrebuilt ''
+    EXTRA_CC_OPTS += -std=gnu99
+  '';
+
+  # Splicer will pull out correct variations
+  libDeps = platform: lib.optional enableTerminfo ncurses
+    ++ [libffi]
+    ++ lib.optional (!enableNativeBignum) gmp
+    ++ lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
+
+  toolsForTarget = [
+    pkgsBuildTarget.targetPackages.stdenv.cc
+  ] ++ lib.optional useLLVM buildLlvmPackages.llvm;
+
+  targetCC = builtins.head toolsForTarget;
+
+  # ld.gold is disabled for musl libc due to https://sourceware.org/bugzilla/show_bug.cgi?id=23856
+  # see #84670 and #49071 for more background.
+  useLdGold = targetPlatform.isLinux && !(targetPlatform.useLLVM or false) && !targetPlatform.isMusl && !targetPlatform.isWindows;
+
+  runtimeDeps = [
+    targetPackages.stdenv.cc.bintools
+    coreutils
+  ]
+  # On darwin, we need unwrapped bintools as well (for otool)
+  ++ lib.optionals (stdenv.targetPlatform.isDarwin) [
+    targetPackages.stdenv.cc.bintools.bintools
+  ];
+
+in
+stdenv.mkDerivation (rec {
+  version = "9.2.1";
+  name = "${targetPrefix}ghc-${version}";
+
+  src = fetchurl {
+    url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";
+    sha256 = "f444012f97a136d9940f77cdff03fda48f9475e2ed0fec966c4d35c4df55f746";
+  };
+
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "doc" ];
+
+  patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
+    ./respect-ar-path.patch
+
+    # cabal passes incorrect --host= when cross-compiling
+    # https://github.com/haskell/cabal/issues/5887
+    (fetchpatch {
+            url = "https://raw.githubusercontent.com/input-output-hk/haskell.nix/122bd81150386867da07fdc9ad5096db6719545a/overlays/patches/ghc/cabal-host.patch";
+      sha256 = "sha256:0yd0sajgi24sc1w5m55lkg2lp6kfkgpp3lgija2c8y3cmkwfpdc1";
+    })
+
+    # In order to build ghcjs packages, the Cabal of the ghc used for the ghcjs
+    # needs to be patched. Ref https://github.com/haskell/cabal/pull/7575
+    (fetchpatch {
+      url = "https://github.com/haskell/cabal/commit/369c4a0a54ad08a9e6b0d3bd303fedd7b5e5a336.patch";
+      sha256 = "120f11hwyaqa0pq9g5l1300crqij49jg0rh83hnp9sa49zfdwx1n";
+      stripLen = 3;
+      extraPrefix = "libraries/Cabal/Cabal/";
+    })
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Make Block.h compile with c++ compilers. Remove with the next release
+    (fetchpatch {
+      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/97d0b0a367e4c6a52a17c3299439ac7de129da24.patch";
+      sha256 = "0r4zjj0bv1x1m2dgxp3adsf2xkr94fjnyj1igsivd9ilbs5ja0b5";
+    })
+  ];
+
+  postPatch = "patchShebangs .";
+
+  # GHC needs the locale configured during the Haddock phase.
+  LANG = "en_US.UTF-8";
+
+  # GHC is a bit confused on its cross terminology.
+  preConfigure = ''
+    for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
+      export "''${env#TARGET_}=''${!env}"
+    done
+    # GHC is a bit confused on its cross terminology, as these would normally be
+    # the *host* tools.
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${lib.optionalString useLdGold ".gold"}"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+
+    echo -n "${buildMK}" > mk/build.mk
+    sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+  '' + lib.optionalString (stdenv.isLinux && hostPlatform.libc == "glibc") ''
+    export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
+  '' + lib.optionalString stdenv.isDarwin ''
+    export NIX_LDFLAGS+=" -no_dtrace_dof"
+  '' + lib.optionalString targetPlatform.useAndroidPrebuilt ''
+    sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
+  '' + lib.optionalString targetPlatform.isMusl ''
+      echo "patching llvm-targets for musl targets..."
+      echo "Cloning these existing '*-linux-gnu*' targets:"
+      grep linux-gnu llvm-targets | sed 's/^/  /'
+      echo "(go go gadget sed)"
+      sed -i 's,\(^.*linux-\)gnu\(.*\)$,\0\n\1musl\2,' llvm-targets
+      echo "llvm-targets now contains these '*-linux-musl*' targets:"
+      grep linux-musl llvm-targets | sed 's/^/  /'
+
+      echo "And now patching to preserve '-musleabi' as done with '-gnueabi'"
+      # (aclocal.m4 is actual source, but patch configure as well since we don't re-gen)
+      for x in configure aclocal.m4; do
+        substituteInPlace $x \
+          --replace '*-android*|*-gnueabi*)' \
+                    '*-android*|*-gnueabi*|*-musleabi*)'
+      done
+  '';
+
+  # TODO(@Ericson2314): Always pass "--target" and always prefix.
+  configurePlatforms = [ "build" "host" ]
+    ++ lib.optional (targetPlatform != hostPlatform) "target";
+
+  # `--with` flags for libraries needed for RTS linker
+  configureFlags = [
+    "--datadir=$doc/share/doc/ghc"
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+  ] ++ lib.optionals (libffi != null) [
+    "--with-system-libffi"
+    "--with-ffi-includes=${targetPackages.libffi.dev}/include"
+    "--with-ffi-libraries=${targetPackages.libffi.out}/lib"
+  ] ++ lib.optionals (targetPlatform == hostPlatform && !enableNativeBignum) [
+    "--with-gmp-includes=${targetPackages.gmp.dev}/include"
+    "--with-gmp-libraries=${targetPackages.gmp.out}/lib"
+  ] ++ lib.optionals (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
+    "--with-iconv-includes=${libiconv}/include"
+    "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ lib.optionals (targetPlatform != hostPlatform) [
+    "--enable-bootstrap-with-devel-snapshot"
+  ] ++ lib.optionals useLdGold [
+    "CFLAGS=-fuse-ld=gold"
+    "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
+    "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
+  ] ++ lib.optionals (disableLargeAddressSpace) [
+    "--disable-large-address-space"
+  ];
+
+  # Make sure we never relax`$PATH` and hooks support for compatibility.
+  strictDeps = true;
+
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
+  nativeBuildInputs = [
+    perl autoconf automake m4 python3 sphinx
+    ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+  ] ++ lib.optionals stdenv.isDarwin [
+    # TODO(@sternenseemann): backport addition of XATTR env var like
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6447
+    xattr
+  ];
+
+  # For building runtime libs
+  depsBuildTarget = toolsForTarget;
+
+  buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
+
+  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
+    ++ lib.optional useLLVM llvmPackages.llvm;
+
+  depsTargetTarget = map lib.getDev (libDeps targetPlatform);
+  depsTargetTargetPropagated = map (lib.getOutput "out") (libDeps targetPlatform);
+
+  # required, because otherwise all symbols from HSffi.o are stripped, and
+  # that in turn causes GHCi to abort
+  stripDebugFlags = [ "-S" ] ++ lib.optional (!targetPlatform.isDarwin) "--keep-file-symbols";
+
+  checkTarget = "test";
+
+  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+
+  postInstall = ''
+    # Install the bash completion file.
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
+
+    # Patch scripts to include "readelf" and "cat" in $PATH.
+    for i in "$out/bin/"*; do
+      test ! -h $i || continue
+      egrep --quiet '^#!' <(head -n 1 $i) || continue
+      sed -i -e '2i export PATH="$PATH:${lib.makeBinPath runtimeDeps}"' $i
+    done
+  '';
+
+  passthru = {
+    inherit bootPkgs targetPrefix;
+
+    inherit llvmPackages;
+    inherit enableShared;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc-${version}";
+  };
+
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "The Glasgow Haskell Compiler";
+    maintainers = with lib.maintainers; [ marcweber andres peti ];
+    timeout = 24 * 3600;
+    inherit (ghc.meta) license platforms;
+  };
+
+} // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {
+  dontStrip = true;
+  dontPatchELF = true;
+  noAuditTmpdir = true;
+})

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -1,0 +1,303 @@
+{ pkgs, haskellLib }:
+
+with haskellLib;
+
+self: super: {
+
+  # This compiler version needs llvm 9.x.
+  llvmPackages = pkgs.llvmPackages_9;
+
+  # Disable GHC 9.2.x core libraries.
+  array = null;
+  base = null;
+  binary = null;
+  bytestring = null;
+  Cabal = null;
+  containers = null;
+  deepseq = null;
+  directory = null;
+  exceptions = null;
+  filepath = null;
+  ghc-bignum = null;
+  ghc-boot = null;
+  ghc-boot-th = null;
+  ghc-compact = null;
+  ghc-heap = null;
+  ghc-prim = null;
+  ghci = null;
+  haskeline = null;
+  hpc = null;
+  integer-gmp = null;
+  libiserv = null;
+  mtl = null;
+  parsec = null;
+  pretty = null;
+  process = null;
+  rts = null;
+  stm = null;
+  template-haskell = null;
+  terminfo = null;
+  text = null;
+  time = null;
+  transformers = null;
+  unix = null;
+  xhtml = null;
+
+  # Workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/20594
+  tf-random = overrideCabal {
+    doHaddock = !pkgs.stdenv.isAarch64;
+  } super.tf-random;
+
+  aeson = appendPatch (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/aeson-1.5.6.0.patch";
+    sha256 = "07rk7f0lhgilxvbg2grpl1p5x25wjf9m7a0wqmi2jr0q61p9a0nl";
+    # The revision information is newer than that included in the patch
+    excludes = ["*.cabal"];
+  }) (doJailbreak super.aeson);
+
+  basement = overrideCabal (drv: {
+    # This is inside a conditional block so `doJailbreak` doesn't work
+    postPatch = "sed -i -e 's,<4.16,<4.17,' basement.cabal";
+  }) (appendPatch (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/basement-0.0.12.patch";
+    sha256 = "0c8n2krz827cv87p3vb1vpl3v0k255aysjx9lq44gz3z1dhxd64z";
+  }) super.basement);
+
+  # Tests fail because of typechecking changes
+  conduit = dontCheck super.conduit;
+
+  cryptonite = appendPatch (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/cryptonite-0.29.patch";
+    sha256 = "1g48lrmqgd88hqvfq3klz7lsrpwrir2v1931myrhh6dy0d9pqj09";
+  }) super.cryptonite;
+
+  # cabal-install needs more recent versions of Cabal
+  cabal-install = (doJailbreak super.cabal-install).overrideScope (self: super: {
+    Cabal = self.Cabal_3_6_2_0;
+  });
+
+  doctest = dontCheck (doJailbreak super.doctest_0_18_2);
+
+  # Tests fail in GHC 9.2
+  extra = dontCheck super.extra;
+
+  # Jailbreaks & Version Updates
+  assoc = doJailbreak super.assoc;
+  async = doJailbreak super.async;
+  attoparsec = super.attoparsec_0_14_4;
+  base64-bytestring = doJailbreak super.base64-bytestring;
+  base-compat = self.base-compat_0_12_1;
+  base-compat-batteries = self.base-compat-batteries_0_12_1;
+  binary-instances = doJailbreak super.binary-instances;
+  binary-orphans = super.binary-orphans_1_0_2;
+  ChasingBottoms = doJailbreak super.ChasingBottoms;
+  constraints = doJailbreak super.constraints;
+  cpphs = overrideCabal (drv: { postPatch = "sed -i -e 's,time >=1.5 && <1.11,time >=1.5 \\&\\& <1.12,' cpphs.cabal";}) super.cpphs;
+  cryptohash-md5 = doJailbreak super.cryptohash-md5;
+  cryptohash-sha1 = doJailbreak super.cryptohash-sha1;
+  data-fix = doJailbreak super.data-fix;
+  dec = doJailbreak super.dec;
+  ed25519 = doJailbreak super.ed25519;
+  genvalidity = self.genvalidity_1_0_0_1;
+  genvalidity-property = self.genvalidity-property_1_0_0_0;
+  genvalidity-hspec = self.genvalidity-hspec_1_0_0_0;
+  ghc-byteorder = doJailbreak super.ghc-byteorder;
+  ghc-exactprint = overrideCabal (drv: {
+    # HACK: ghc-exactprint 1.4.1 is not buildable for GHC < 9.2,
+    # but hackage2nix evaluates the cabal file with GHC 8.10.*,
+    # causing the build-depends to be skipped. Since the dependency
+    # list hasn't changed much since 0.6.4, we can just reuse the
+    # normal expression.
+    inherit (self.ghc-exactprint_1_4_1) src version;
+    revision = null; editedCabalFile = null;
+    libraryHaskellDepends = [
+      self.fail
+      self.ordered-containers
+    ] ++ drv.libraryHaskellDepends or [];
+  }) super.ghc-exactprint;
+  ghc-lib = self.ghc-lib_9_2_1_20220109;
+  ghc-lib-parser = self.ghc-lib-parser_9_2_1_20220109;
+  ghc-lib-parser-ex = self.ghc-lib-parser-ex_9_2_0_1;
+  hackage-security = doJailbreak super.hackage-security;
+  hashable = super.hashable_1_4_0_2;
+  hashable-time = doJailbreak super.hashable-time_0_3;
+  hedgehog = doJailbreak super.hedgehog;
+  HTTP = overrideCabal (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; }) (doJailbreak super.HTTP);
+  integer-logarithms = overrideCabal (drv: { postPatch = "sed -i -e 's, <1.1, <1.3,' integer-logarithms.cabal"; }) (doJailbreak super.integer-logarithms);
+  indexed-traversable = doJailbreak super.indexed-traversable;
+  indexed-traversable-instances = doJailbreak super.indexed-traversable-instances;
+  lifted-async = doJailbreak super.lifted-async;
+  lukko = doJailbreak super.lukko;
+  network = super.network_3_1_2_7;
+  ormolu = self.ormolu_0_4_0_0;
+  OneTuple = super.OneTuple_0_3_1;
+  parallel = doJailbreak super.parallel;
+  path = doJailbreak super.path_0_9_2;
+  polyparse = overrideCabal (drv: { postPatch = "sed -i -e 's, <0.11, <0.12,' polyparse.cabal"; }) (doJailbreak super.polyparse);
+  primitive = doJailbreak super.primitive;
+  quickcheck-instances = super.quickcheck-instances_0_3_27;
+  regex-posix = doJailbreak super.regex-posix;
+  resolv = doJailbreak super.resolv;
+  retrie = doDistribute self.retrie_1_2_0_1;
+  semialign = super.semialign_1_2_0_1;
+  singleton-bool = doJailbreak super.singleton-bool;
+  scientific = doJailbreak super.scientific;
+  shelly = doJailbreak super.shelly;
+  split = doJailbreak super.split;
+  splitmix = doJailbreak super.splitmix;
+  tar = doJailbreak super.tar;
+  tasty-hedgehog = doJailbreak super.tasty-hedgehog;
+  tasty-hspec = doJailbreak super.tasty-hspec;
+  th-desugar = self.th-desugar_1_13;
+  these = doJailbreak super.these;
+  time-compat = doJailbreak super.time-compat_1_9_6_1;
+  type-equality = doJailbreak super.type-equality;
+  unordered-containers = doJailbreak super.unordered-containers;
+  vector = doJailbreak (dontCheck super.vector);
+  vector-binary-instances = doJailbreak super.vector-binary-instances;
+  # Upper bound on `hashable` is too restrictive
+  witherable = doJailbreak super.witherable;
+  zlib = doJailbreak super.zlib;
+
+  hpack = overrideCabal (drv: {
+    # Cabal 3.6 seems to preserve comments when reading, which makes this test fail
+    # 2021-10-10: 9.2.1 is not yet supported (also no issue)
+    testFlags = [
+      "--skip=/Hpack/renderCabalFile/is inverse to readCabalFile/"
+    ] ++ drv.testFlags or [];
+  }) (doJailbreak super.hpack);
+
+  validity = pkgs.lib.pipe super.validity_0_12_0_0 [
+    # head.hackage patch
+    (appendPatch (pkgs.fetchpatch {
+      url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/9110e6972b5daf085e19cad41f97920d3ddac499/patches/validity-0.12.0.0.patch";
+      sha256 = "0hzns596dxvyn8irgi7aflx76wak1qi13chkkvl0055pkgykm08f";
+    }))
+    # head.hackage ignores test suite
+    dontCheck
+  ];
+
+  # Deviate from Stackage LTS-15.x to fix the build.
+  haddock-library = self.haddock-library_1_9_0;
+
+  # Jailbreak to fix the build.
+  base-noprelude = doJailbreak super.base-noprelude;
+  system-fileio = doJailbreak super.system-fileio;
+  unliftio-core = doJailbreak super.unliftio-core;
+
+  # Use the latest version to fix the build.
+  dhall = self.dhall_1_34_0;
+
+  # lens >= 5.1 supports 9.2.1
+  lens = self.lens_5_1;
+
+  optics = self.optics_0_3;
+  optics-core = self.optics-core_0_3_0_1;
+  optics-extra = self.optics-extra_0_3;
+  optics-th = self.optics-th_0_3_0_2;
+  repline = self.repline_0_4_0_0;
+  singletons = self.singletons_2_7;
+  th-desugar = self.th-desugar_1_11;
+
+  insert-ordered-containers = super.insert-ordered-containers.override {
+    optics-core = self.optics-core_0_3_0_1;
+    optics-extra = self.optics-extra_0_3.override {
+      optics-core = self.optics-core_0_3_0_1;
+    };
+  };
+
+  # Jailbreaking because monoidal-containers hasn‘t bumped it's base dependency for 8.10.
+  monoidal-containers = doJailbreak super.monoidal-containers;
+
+  # `ghc-lib-parser-ex` (see conditionals in its `.cabal` file) does not need
+  # the `ghc-lib-parser` dependency on GHC >= 8.8. However, because we have
+  # multiple verions of `ghc-lib-parser(-ex)` available, and the default ones
+  # are older ones, those older ones will complain. Because we have a newer
+  # GHC, we can just set the dependency to `null` as it is not used.
+  ghc-lib-parser-ex = super.ghc-lib-parser-ex.override { ghc-lib-parser = null; };
+
+  # Jailbreak to fix the build.
+  brick = doJailbreak super.brick;
+  exact-pi = doJailbreak super.exact-pi;
+  serialise = doJailbreak super.serialise;
+  setlocale = doJailbreak super.setlocale;
+  shellmet = doJailbreak super.shellmet;
+  shower = doJailbreak super.shower;
+
+  # The shipped Setup.hs file is broken.
+  csv = overrideCabal super.csv (drv: { preCompileBuildDriver = "rm Setup.hs"; });
+
+  # Syntax error in tests fixed in https://github.com/simonmar/alex/commit/84b29475e057ef744f32a94bc0d3954b84160760
+  alex = dontCheck super.alex;
+
+  # Apply patches from head.hackage.
+  language-haskell-extract = appendPatch (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/language-haskell-extract-0.2.4.patch";
+    sha256 = "0w4y3v69nd3yafpml4gr23l94bdhbmx8xky48a59lckmz5x9fgxv";
+  }) (doJailbreak super.language-haskell-extract);
+
+  haskell-src-meta = appendPatch (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/haskell-src-meta-0.8.7.patch";
+    sha256 = "013k8hpxac226j47cdzgdf9a1j91kmm0cvv7n8zwlajbj3y9bzjp";
+  }) (doJailbreak super.haskell-src-meta);
+
+  apply-refact = super.apply-refact_0_9_3_0;
+
+  # Tests depend on `parseTime` which is no longer available
+  hourglass = dontCheck super.hourglass;
+
+  # https://github.com/commercialhaskell/pantry/issues/21
+  pantry = super.pantry_0_5_2_3;
+
+  hnix = super.hnix_0_14_0_8;
+
+# 1.2.1 introduced support for GHC 9.2.1, stackage has 1.2.0
+  # The test suite indirectly depends on random, which leads to infinite recursion
+  random = dontCheck super.random_1_2_1;
+
+  # 0.16.0 introduced support for GHC 9.0.x, stackage has 0.15.0
+  memory = appendPatch (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/memory-0.16.0.patch";
+    sha256 = "1kjganx729a6xfgfnrb3z7q6mvnidl042zrsd9n5n5a3i76nl5nl";
+  }) (overrideCabal {
+    editedCabalFile = null;
+    revision = null;
+  } super.memory_0_16_0);
+
+  # GHC 9.0.x doesn't like `import Spec (main)` in Main.hs
+  # https://github.com/snoyberg/mono-traversable/issues/192
+  mono-traversable = dontCheck super.mono-traversable;
+
+  # Disable tests pending resolution of
+  # https://github.com/Soostone/retry/issues/71
+  retry = dontCheck super.retry;
+
+  # Upper bound on `hashable` is too restrictive
+  semigroupoids = overrideCabal (drv: { postPatch = "sed -i -e 's,hashable >= 1.2.7.0  && < 1.4,hashable >= 1.2.7.0  \\&\\& < 1.5,' semigroupoids.cabal";}) super.semigroupoids;
+
+  # Tests have a circular dependency on quickcheck-instances
+  text-short = dontCheck super.text-short_0_1_5;
+
+  # Use hlint from git for GHC 9.2.1 support
+  hlint = doDistribute (
+    overrideSrc {
+      version = "unstable-2021-12-12";
+      src = pkgs.fetchFromGitHub {
+        owner = "ndmitchell";
+        repo = "hlint";
+        rev = "77a9702e10b772a7695c08682cd4f450fd0e9e46";
+        sha256 = "0hpp3iw7m7w2abr8vb86gdz3x6c8lj119zxln933k90ia7bmk8jc";
+      };
+    } (super.hlint_3_3_6.overrideScope (self: super: {
+      ghc-lib-parser = self.ghc-lib-parser_9_2_1_20220109;
+      ghc-lib-parser-ex = self.ghc-lib-parser-ex_9_2_0_1;
+    }))
+  );
+
+  # https://github.com/sjakobi/bsb-http-chunked/issues/38
+  bsb-http-chunked = dontCheck super.bsb-http-chunked;
+
+  # need bytestring >= 0.11 which is only bundled with GHC >= 9.2
+  regex-rure = doDistribute (markUnbroken super.regex-rure);
+  jacinda = doDistribute super.jacinda;
+}

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -12,10 +12,12 @@ let
     "ghcjs810"
     "integer-simple"
     "native-bignum"
+    "ghc921"
     "ghcHEAD"
   ];
 
   nativeBignumIncludes = [
+    "ghc921"
     "ghcHEAD"
   ];
 
@@ -139,6 +141,21 @@ in {
       buildLlvmPackages = buildPackages.llvmPackages_9;
       llvmPackages = pkgs.llvmPackages_9;
     };
+    ghc921 = callPackage ../development/compilers/ghc/9.2.1.nix {
+      bootPkgs =
+        # aarch64 ghc8107Binary exceeds max output size on hydra
+        if stdenv.isAarch64 || stdenv.isAarch32 then
+          packages.ghc8107BinaryMinimal
+        else
+          packages.ghc8107Binary;
+      inherit (buildPackages.python3Packages) sphinx;
+      # Need to use apple's patched xattr until
+      # https://github.com/xattr/xattr/issues/44 and
+      # https://github.com/xattr/xattr/issues/55 are solved.
+      inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
+      buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_12;
+      llvmPackages = pkgs.llvmPackages_12;
+    };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
       bootPkgs = packages.ghc883; # no binary yet
       inherit (buildPackages.python3Packages) sphinx;
@@ -255,6 +272,11 @@ in {
       buildHaskellPackages = bh.packages.ghc8107;
       ghc = bh.compiler.ghc8107;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
+    };
+    ghc921 = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc921;
+      ghc = bh.compiler.ghc921;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.2.x.nix { };
     };
     ghcHEAD = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghcHEAD;


### PR DESCRIPTION
###### Motivation for this change

GHC 9.2 has a number of new extensions we would like to explore, such as UnliftedDatatypes.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
