### PR TITLE
modules/boot: Specify the type for tmpfs mounts

### DIFF
--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -34,6 +34,7 @@ with lib;
       {
         what = "tmpfs";
         where = "/tmp";
+        type = "tmpfs";
         mountConfig.Options = [ "mode=1777" "strictatime" "rw" "nosuid" "nodev" "size=50%" ];
       }
     ];


### PR DESCRIPTION
Backport of ca7b35d2d9c276cf08d9ca8248eae004f4e9d295 to `awake-20.09`

Related to https://awakesecurity.atlassian.net/browse/MONAPP-26471