### PR TITLE
nixos-install: Disable min-free

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -84,6 +84,8 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
+extraBuildFlags+=('--option' 'min-free' '0')
+
 if ! test -e "$mountPoint"; then
     echo "mount point $mountPoint doesn't exist"
     exit 1


### PR DESCRIPTION
Fixes https://awakesecurity.atlassian.net/browse/MONAPP-27168

`make-disk-image` was hanging in the middle of the `nixos-install`
step:

https://github.com/NixOS/nixpkgs/blob/41c440bebe969c5fc70c97f6b95536b33d50b152/nixos/lib/make-disk-image.nix#L279-L282

… specifically the `nix-env` sub-step:

https://github.com/NixOS/nixpkgs/blob/e6f82bab843bd083cc7b46448a3a73809791713f/nixos/modules/installer/tools/nixos-install.sh#L165-L167

… if an auto-GC was triggered via the min-free option in the middle
of that step.  The fix is to disable `min-free` during a `nixos-install`
to prevent this from happening.