### PR TITLE
python3Packages: Backport several packages

### DIFF
--- a/pkgs/development/python-modules/aiopg/default.nix
+++ b/pkgs/development/python-modules/aiopg/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "aiopg";
-  version = "1.3.2";
+  version = "1.3.3";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-e7USw3Bx6cpLu9PKDC+eEdPTSjriuSX2Sg+9BeRa9Ko=";
+    sha256 = "sha256-GHKsI6JATiwUg+YlGhWPBqtYl+GyXWNiDi/hzPDl2hE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiopg/default.nix
+++ b/pkgs/development/python-modules/aiopg/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "aiopg";
-  version = "1.3.1";
+  version = "1.3.2";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-kAkxulAMtLeL3IAuIVvZtsN5RxHWV/qHyFIYu9Odn34=";
+    sha256 = "sha256-e7USw3Bx6cpLu9PKDC+eEdPTSjriuSX2Sg+9BeRa9Ko=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiopg/default.nix
+++ b/pkgs/development/python-modules/aiopg/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "aiopg";
-  version = "1.3.0";
+  version = "1.3.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-/J53WqBag4ArSF7wETvmoBUtgNqp4eYGH0ytipiSKBI=";
+    sha256 = "sha256-kAkxulAMtLeL3IAuIVvZtsN5RxHWV/qHyFIYu9Odn34=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiopg/default.nix
+++ b/pkgs/development/python-modules/aiopg/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "aiopg";
-  version = "1.2.1";
+  version = "1.3.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0c6s2p1fjbdk1ygpl6a1s1rbnsk8gw9kj99pf98nxhb9j3iahas4";
+    sha256 = "sha256-/J53WqBag4ArSF7wETvmoBUtgNqp4eYGH0ytipiSKBI=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "anyio";
-  version = "3.2.1";
+  version = "3.3.0";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "agronholm";
     repo = pname;
     rev = version;
-    sha256 = "0fiqzsgr9c0yicsh1pwhyc6z4qyr2ng42dakyy4a81w9cff38had";
+    sha256 = "sha256-bMnAijFLXZSgTWsalT/J4sJ0Jrc1kFaQHJArwXnQFaQ=";
   };
 
   preBuild = ''
@@ -57,8 +57,13 @@ buildPythonPackage rec {
     mock
   ];
 
+  disabledTests = [
+    # block devices access
+    "test_is_block_device"
+  ];
+
   disabledTestPaths = [
-     # lots of DNS lookups
+    # lots of DNS lookups
     "tests/test_sockets.py"
   ] ++ lib.optionals stdenv.isDarwin [
     # darwin sandboxing limitations

--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "anyio";
-  version = "3.3.1";
+  version = "3.3.2";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "agronholm";
     repo = pname;
     rev = version;
-    sha256 = "sha256-JQf+OWHV2Vok5FmP7mlzeqbKUlxB+FC1c3ruX2aQEEs=";
+    sha256 = "sha256-XBIrFb/XDneaOf/TeHxyeEfyQ7qQcWO7LJF0k1f4Ark=";
   };
 
   preBuild = ''

--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "anyio";
-  version = "3.3.0";
+  version = "3.3.1";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "agronholm";
     repo = pname;
     rev = version;
-    sha256 = "sha256-bMnAijFLXZSgTWsalT/J4sJ0Jrc1kFaQHJArwXnQFaQ=";
+    sha256 = "sha256-JQf+OWHV2Vok5FmP7mlzeqbKUlxB+FC1c3ruX2aQEEs=";
   };
 
   preBuild = ''

--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -8,6 +8,8 @@
 , typing-extensions
 , curio
 , hypothesis
+, mock
+, pytest-mock
 , pytestCheckHook
 , trio
 , trustme
@@ -16,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "anyio";
-  version = "2.2.0";
+  version = "3.1.0";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
@@ -24,7 +26,7 @@ buildPythonPackage rec {
     owner = "agronholm";
     repo = pname;
     rev = version;
-    sha256 = "0ram1niv2lg9qj53zssph104a4kxl8f94ilfn6mibn034m3ikcc8";
+    sha256 = "sha256-zQiSAQN7cp1s+8hDTvYaMkHUXV1ccNwIsl2IOztH7J8=";
   };
 
   propagatedBuildInputs = [
@@ -37,18 +39,21 @@ buildPythonPackage rec {
   checkInputs = [
     curio
     hypothesis
+    pytest-mock
     pytestCheckHook
     trio
     trustme
     uvloop
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    mock
   ];
 
-  pytestFlagsArray = [
-    # lots of DNS lookups
-    "--ignore=tests/test_sockets.py"
+  disabledTestPaths = [
+     # lots of DNS lookups
+    "tests/test_sockets.py"
   ] ++ lib.optionals stdenv.isDarwin [
     # darwin sandboxing limitations
-    "--ignore=tests/streams/test_tls.py"
+    "tests/streams/test_tls.py"
   ];
 
   pythonImportsCheck = [ "anyio" ];

--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, setuptools-scm
 , idna
 , sniffio
 , typing-extensions
@@ -18,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "anyio";
-  version = "3.1.0";
+  version = "3.2.0";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
@@ -28,6 +29,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "sha256-zQiSAQN7cp1s+8hDTvYaMkHUXV1ccNwIsl2IOztH7J8=";
   };
+
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION=${version}
+  '';
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
   propagatedBuildInputs = [
     idna

--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "anyio";
-  version = "3.2.0";
+  version = "3.2.1";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "agronholm";
     repo = pname;
     rev = version;
-    sha256 = "sha256-zQiSAQN7cp1s+8hDTvYaMkHUXV1ccNwIsl2IOztH7J8=";
+    sha256 = "0fiqzsgr9c0yicsh1pwhyc6z4qyr2ng42dakyy4a81w9cff38had";
   };
 
   preBuild = ''

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -44,6 +44,11 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
+  # test server needs to be available
+  preCheck = ''
+    export PYTHONPATH=tests/testserver_tests/coretestserver:$PYTHONPATH
+  '';
+
   pytestFlagsArray = [ "tests/" ];
   # disable tests which touch network
   disabledTests = [ "aiohttp" "multipart_send" "response" "request" "timeout" ];

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -15,14 +15,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.16.0";
+  version = "1.17.0";
   pname = "azure-core";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "b1c7d2e01846074f258c8b2e592239aef836a2b1c27d8d0e8491a2c7e2906ef4";
+    sha256 = "25407390dde142d3e41ecf78bb18cedda9b7f7a0af558d082dec711c4a334f46";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -15,14 +15,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.17.0";
+  version = "1.20.1";
   pname = "azure-core";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "25407390dde142d3e41ecf78bb18cedda9b7f7a0af558d082dec711c4a334f46";
+    sha256 = "21d06311c9c373e394ed9f9db035306773334a0181932e265889eca34d778d17";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -1,6 +1,7 @@
 { lib, buildPythonPackage, fetchPypi, isPy27
 , aiodns
 , aiohttp
+, flask
 , mock
 , msrest
 , pytest
@@ -14,14 +15,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.15.0";
+  version = "1.16.0";
   pname = "azure-core";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "197917b98fec661c35392e32abec4f690ac2117371a814e25e57c224ce23cf1f";
+    sha256 = "b1c7d2e01846074f258c8b2e592239aef836a2b1c27d8d0e8491a2c7e2906ef4";
   };
 
   propagatedBuildInputs = [
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   checkInputs = [
     aiodns
     aiohttp
+    flask
     mock
     msrest
     pytest
@@ -51,6 +53,8 @@ buildPythonPackage rec {
     # wants network
     "tests/async_tests/test_streaming_async.py"
     "tests/test_streaming.py"
+    # testserver tests require being in a very specific working directory to make it work
+    "tests/testserver_tests/"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -14,14 +14,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.14.0";
+  version = "1.15.0";
   pname = "azure-core";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "f32bb64aabe61f496255c16dd6c555a027da628109460bf27311cee0caf78f96";
+    sha256 = "197917b98fec661c35392e32abec4f690ac2117371a814e25e57c224ce23cf1f";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -60,6 +60,9 @@ buildPythonPackage rec {
     "tests/test_streaming.py"
     # testserver tests require being in a very specific working directory to make it work
     "tests/testserver_tests/"
+
+    "tests/test_rest_polling.py"
+    "tests/async_tests/test_rest_polling_async.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/azure-cosmos/default.nix
+++ b/pkgs/development/python-modules/azure-cosmos/default.nix
@@ -7,12 +7,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "3.1.2";
+  version = "3.2.0";
   pname = "azure-cosmos";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7f8ac99e4e40c398089fc383bfadcdc83376f72b88532b0cac0b420357cd08c7";
+    sha256 = "4f77cc558fecffac04377ba758ac4e23f076dc1c54e2cf2515f85bc15cbde5c6";
   };
 
   propagatedBuildInputs = [ six requests ];

--- a/pkgs/development/python-modules/azure-cosmos/default.nix
+++ b/pkgs/development/python-modules/azure-cosmos/default.nix
@@ -4,18 +4,20 @@
 , fetchPypi
 , six
 , requests
+, azure-core
 }:
 
 buildPythonPackage rec {
-  version = "3.2.0";
+  version = "4.2.0";
   pname = "azure-cosmos";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4f77cc558fecffac04377ba758ac4e23f076dc1c54e2cf2515f85bc15cbde5c6";
+    extension = "zip";
+    sha256 = "867191fa5966446101f7ca3834f23060a85735d0b660303ca353864945d572b6";
   };
 
-  propagatedBuildInputs = [ six requests ];
+  propagatedBuildInputs = [ six requests azure-core ];
 
   pythonNamespaces = [ "azure" ];
 

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -23,18 +23,18 @@
 
 buildPythonPackage rec {
   pname = "cryptography";
-  version = "3.4.7"; # Also update the hash in vectors.nix
+  version = "3.4.8"; # Also update the hash in vectors.nix
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04x7bhjkglxpllad10821vxddlmxdkd3gjvp35iljmnj2s0xw41x";
+    sha256 = "072awar70cwfd2hnx0pvp1dkc7gw45mbm3wcyddvxz5frva5xk4l";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     sourceRoot = "${pname}-${version}/${cargoRoot}";
     name = "${pname}-${version}";
-    sha256 = "1m6smky4nahwlp4hn6yzibrcxlbsw4nx162dsq48vlw8h1lgjl62";
+    sha256 = "01h511h6l4qvjxbaw662m1l84pb4wrhwxmnb3qj6ik13mx2m477m";
   };
 
   cargoRoot = "src/rust";

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1hh4j88ywil3jf62ppj1blygmdirbqz86pynd9lqfijiaym3mb57";
+    sha256 = "1wl0ynh3lzhc6q59g8mybvijmnp195x7fjxlb3h3sgcraw14312c";
   };
 
   # No tests included

--- a/pkgs/development/python-modules/databases/default.nix
+++ b/pkgs/development/python-modules/databases/default.nix
@@ -3,7 +3,8 @@
 , fetchFromGitHub
 , sqlalchemy
 , aiocontextvars
-, isPy27
+, aiopg
+, pythonOlder
 , pytestCheckHook
 , pymysql
 , asyncpg
@@ -13,42 +14,48 @@
 
 buildPythonPackage rec {
   pname = "databases";
-  version = "0.5.2";
-  disabled = isPy27;
+  version = "0.5.3";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OfBb78lKnAxPhyy2j4TzEZWBzbw64brTQcxuOPoW9pk=";
+    sha256 = "sha256-67ykx7HKGgRvJ+GRVEI/e2+x51kfHHFjh/iI4tY+6aE=";
   };
 
   propagatedBuildInputs = [
-    aiocontextvars
-    sqlalchemy
-  ];
-
-  checkInputs = [
+    aiopg
     aiomysql
     aiosqlite
     asyncpg
     pymysql
+    sqlalchemy
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    aiocontextvars
+  ];
+
+  checkInputs = [
     pytestCheckHook
   ];
 
   disabledTestPaths = [
-    # ModuleNotFoundError: No module named 'aiopg'
-    "tests/test_connection_options.py"
     # circular dependency on starlette
     "tests/test_integration.py"
     # TEST_DATABASE_URLS is not set.
     "tests/test_databases.py"
+    "tests/test_connection_options.py"
+  ];
+
+  pythonImportsCheck = [
+    "databases"
   ];
 
   meta = with lib; {
     description = "Async database support for Python";
     homepage = "https://github.com/encode/databases";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/databases/default.nix
+++ b/pkgs/development/python-modules/databases/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , sqlalchemy
 , aiocontextvars
 , isPy27
@@ -22,6 +23,18 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "0aq88k7d9036cy6qvlfv9p2dxd6p6fic3j0az43gn6k1ardhdsgf";
   };
+
+  patches = [
+    # sqlalchemy 1.4 compat, https://github.com/encode/databases/pull/299
+    (fetchpatch {
+      url = "https://github.com/encode/databases/commit/9d6e0c024833bd41421f0798a94ef2bbf27a31d5.patch";
+      sha256 = "0wz9dz6g88ifvvwlhy249cjvqpx72x99wklzcl7b23srpcvb5gv1";
+    })
+    (fetchpatch {
+      url = "https://github.com/encode/databases/commit/40c41c2b7b3fedae484ad94d81b27ce88a09c5ed.patch";
+      sha256 = "0z458l3vkg4faxbnf31lszfby5d10fa9kgxxy4xxcm0py6d8a2pi";
+    })
+  ];
 
   propagatedBuildInputs = [
     aiocontextvars

--- a/pkgs/development/python-modules/databases/default.nix
+++ b/pkgs/development/python-modules/databases/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , sqlalchemy
 , aiocontextvars
 , isPy27
@@ -14,27 +13,15 @@
 
 buildPythonPackage rec {
   pname = "databases";
-  version = "0.4.3";
+  version = "0.5.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "0aq88k7d9036cy6qvlfv9p2dxd6p6fic3j0az43gn6k1ardhdsgf";
+    sha256 = "sha256-HNSPLmZTXZL1e5E9VJiXnQuO2WiXLYOveNTlFqdlTG8=";
   };
-
-  patches = [
-    # sqlalchemy 1.4 compat, https://github.com/encode/databases/pull/299
-    (fetchpatch {
-      url = "https://github.com/encode/databases/commit/9d6e0c024833bd41421f0798a94ef2bbf27a31d5.patch";
-      sha256 = "0wz9dz6g88ifvvwlhy249cjvqpx72x99wklzcl7b23srpcvb5gv1";
-    })
-    (fetchpatch {
-      url = "https://github.com/encode/databases/commit/40c41c2b7b3fedae484ad94d81b27ce88a09c5ed.patch";
-      sha256 = "0z458l3vkg4faxbnf31lszfby5d10fa9kgxxy4xxcm0py6d8a2pi";
-    })
-  ];
 
   propagatedBuildInputs = [
     aiocontextvars

--- a/pkgs/development/python-modules/databases/default.nix
+++ b/pkgs/development/python-modules/databases/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "databases";
-  version = "0.5.0";
+  version = "0.5.2";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "sha256-HNSPLmZTXZL1e5E9VJiXnQuO2WiXLYOveNTlFqdlTG8=";
+    sha256 = "sha256-OfBb78lKnAxPhyy2j4TzEZWBzbw64brTQcxuOPoW9pk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.67.0";
+  version = "0.68.0";
   format = "flit";
 
   src = fetchFromGitHub {
     owner = "tiangolo";
     repo = "fastapi";
     rev = version;
-    sha256 = "15zbalyib7ndcbxvf9prj0n9n6qb4bfzhmaacsjrvdmjzmqdjgw0";
+    sha256 = "00cjkc90h0qlca30g981zvwlxh2wc3rfipw25v667jdl9x5gxv9p";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -55,8 +55,18 @@ buildPythonPackage rec {
   # ignoring deprecation warnings to avoid test failure from
   # tests/test_tutorial/test_testing/test_tutorial001.py
 
-  pytestFlagsArray = [ "--ignore=tests/test_default_response_class.py" "-W ignore::DeprecationWarning"];
-  disabledTests = [ "test_get_custom_response" ];
+  pytestFlagsArray = [
+    "--ignore=tests/test_default_response_class.py"
+    "-W ignore::DeprecationWarning"
+  ];
+
+  disabledTests = [
+    "test_get_custom_response"
+
+    # Failed: DID NOT RAISE <class 'starlette.websockets.WebSocketDisconnect'>
+    "test_websocket_invalid_data"
+    "test_websocket_no_credentials"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/tiangolo/fastapi";

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.68.0";
+  version = "0.68.1";
   format = "flit";
 
   src = fetchFromGitHub {
     owner = "tiangolo";
     repo = "fastapi";
     rev = version;
-    sha256 = "00cjkc90h0qlca30g981zvwlxh2wc3rfipw25v667jdl9x5gxv9p";
+    sha256 = "sha256-zwfopyig4ImMbkx89l8SsLW8PzoVcDN5KSd7a7fOnms=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -13,18 +13,19 @@
 , peewee
 , python-jose
 , sqlalchemy
+, trio
 }:
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.68.1";
+  version = "0.70.0";
   format = "flit";
 
   src = fetchFromGitHub {
     owner = "tiangolo";
     repo = "fastapi";
     rev = version;
-    sha256 = "sha256-zwfopyig4ImMbkx89l8SsLW8PzoVcDN5KSd7a7fOnms=";
+    sha256 = "sha256-mLI+w9PeewnwUMuUnXj6J2r/3shinjlwXMnhNcQlhrM=";
   };
 
   postPatch = ''
@@ -48,6 +49,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
     sqlalchemy
+    trio
   ];
 
   # disabled tests require orjson which requires rust nightly

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.65.2";
+  version = "0.67.0";
   format = "flit";
 
   src = fetchFromGitHub {
     owner = "tiangolo";
     repo = "fastapi";
     rev = version;
-    sha256 = "032srvbfdy02m1b664x67lkdcx6b2bd4c9a9cb176lscjk213240";
+    sha256 = "15zbalyib7ndcbxvf9prj0n9n6qb4bfzhmaacsjrvdmjzmqdjgw0";
   };
 
   postPatch = ''
@@ -51,7 +51,11 @@ buildPythonPackage rec {
   ];
 
   # disabled tests require orjson which requires rust nightly
-  pytestFlagsArray = [ "--ignore=tests/test_default_response_class.py" ];
+
+  # ignoring deprecation warnings to avoid test failure from
+  # tests/test_tutorial/test_testing/test_tutorial001.py
+
+  pytestFlagsArray = [ "--ignore=tests/test_default_response_class.py" "-W ignore::DeprecationWarning"];
   disabledTests = [ "test_get_custom_response" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/importlib-resources/default.nix
+++ b/pkgs/development/python-modules/importlib-resources/default.nix
@@ -11,24 +11,33 @@
 
 buildPythonPackage rec {
   pname = "importlib-resources";
-  version = "5.2.2";
+  version = "5.4.0";
 
   src = fetchPypi {
     pname = "importlib_resources";
     inherit version;
-    sha256 = "sha256-pliCpND+X79wInNFa6LOdP5EiSwl5C4FespSa3AqbUs=";
+    sha256 = "sha256-11bi+F3U3iuom+CyHboqO77C6HGkKjoWcZJYoR+HUGs=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
   propagatedBuildInputs = [
     importlib-metadata
-  ] ++ lib.optional (pythonOlder "3.4") singledispatch
-    ++ lib.optional (pythonOlder "3.5") typing
-  ;
+  ] ++ lib.optional (pythonOlder "3.4") [
+    singledispatch
+  ] ++ lib.optional (pythonOlder "3.5") [
+    typing
+  ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest discover
   '';
+
+  pythonImportsCheck = [
+    "importlib_resources"
+  ];
 
   meta = with lib; {
     description = "Read resources from Python packages";

--- a/pkgs/development/python-modules/importlib-resources/default.nix
+++ b/pkgs/development/python-modules/importlib-resources/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "importlib-resources";
-  version = "5.1.2";
+  version = "5.2.2";
 
   src = fetchPypi {
     pname = "importlib_resources";
     inherit version;
-    sha256 = "642586fc4740bd1cad7690f836b3321309402b20b332529f25617ff18e8e1370";
+    sha256 = "sha256-pliCpND+X79wInNFa6LOdP5EiSwl5C4FespSa3AqbUs=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/llvmlite/default.nix
+++ b/pkgs/development/python-modules/llvmlite/default.nix
@@ -12,17 +12,17 @@
 
 buildPythonPackage rec {
   pname = "llvmlite";
-  version = "0.36.0";
+  version = "0.37.0";
 
   disabled = isPyPy || !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "765128fdf5f149ed0b889ffbe2b05eb1717f8e20a5c87fa2b4018fbcce0fcfc9";
+    sha256 = "6392b870cd018ec0c645d6bbb918d6aa0eeca8c62674baaee30862d6b6865b15";
   };
 
   nativeBuildInputs = [ llvm ];
-  propagatedBuildInputs = [ ] ++ lib.optional (pythonOlder "3.4") enum34;
+  propagatedBuildInputs = lib.optional (pythonOlder "3.4") enum34;
 
   # Disable static linking
   # https://github.com/numba/llvmlite/issues/93
@@ -31,10 +31,12 @@ buildPythonPackage rec {
 
     substituteInPlace llvmlite/tests/test_binding.py --replace "test_linux" "nope"
   '';
+
   # Set directory containing llvm-config binary
   preConfigure = ''
     export LLVM_CONFIG=${llvm.dev}/bin/llvm-config
   '';
+
   checkPhase = ''
     ${python.executable} runtests.py
   '';

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -12,13 +12,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.54.0";
+  version = "0.54.1";
   pname = "numba";
   disabled = pythonOlder "3.6" || pythonAtLeast "3.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bad6bd98ab2e41c34aa9c80b8d9737e07d92a53df4f74d3ada1458b0b516ccff";
+    sha256 = "f9dfc803c864edcc2381219b800abf366793400aea55e26d4d5b7d953e14f43f";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -12,28 +12,39 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.53.1";
+  version = "0.54.0";
   pname = "numba";
   disabled = pythonOlder "3.6" || pythonAtLeast "3.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9cd4e5216acdc66c4e9dab2dfd22ddb5bef151185c070d4a3cd8e78638aff5b0";
+    sha256 = "bad6bd98ab2e41c34aa9c80b8d9737e07d92a53df4f74d3ada1458b0b516ccff";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "1.21" "1.22"
+
+    substituteInPlace numba/__init__.py \
+      --replace "(1, 20)" "(1, 21)"
+  '';
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
 
   propagatedBuildInputs = [ numpy llvmlite setuptools ];
-  pythonImportsCheck = [ "numba" ];
+
   # Copy test script into $out and run the test suite.
   checkPhase = ''
     ${python.interpreter} -m numba.runtests
   '';
+
   # ImportError: cannot import name '_typeconv'
   doCheck = false;
 
+  pythonImportsCheck = [ "numba" ];
+
   meta =  with lib; {
-    homepage = "http://numba.pydata.org/";
+    homepage = "https://numba.pydata.org/";
     license = licenses.bsd2;
     description = "Compiling Python code using LLVM";
     maintainers = with maintainers; [ fridh ];

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -12,14 +12,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.53.0";
+  version = "0.53.1";
   pname = "numba";
   # uses f-strings, python 3.9 is not yet supported
   disabled = pythonOlder "3.6" || pythonAtLeast "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "55c11d7edbba2ba715f2b56f5294cad55cfd87bff98e2627c3047c2d5cc52d16";
+    sha256 = "9cd4e5216acdc66c4e9dab2dfd22ddb5bef151185c070d4a3cd8e78638aff5b0";
   };
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -14,8 +14,7 @@
 buildPythonPackage rec {
   version = "0.53.1";
   pname = "numba";
-  # uses f-strings, python 3.9 is not yet supported
-  disabled = pythonOlder "3.6" || pythonAtLeast "3.9";
+  disabled = pythonOlder "3.6" || pythonAtLeast "3.10";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/parameterizedtestcase/default.nix
+++ b/pkgs/development/python-modules/parameterizedtestcase/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "parameterizedtestcase";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4ccc1d15d7e7ef153619a6a9cd45b170268cf82c67fdd336794c75139aae127e";
+  };
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m parameterizedtestcase.tests
+    runHook postCheck
+  '';
+
+  doCheck = isPy27;
+
+  meta = with lib; {
+    description = "Parameterized tests for Python's unittest module";
+    homepage = "https://github.com/msabramo/python_unittest_parameterized_test_case";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/python-jose/default.nix
+++ b/pkgs/development/python-modules/python-jose/default.nix
@@ -1,46 +1,50 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, future, six, ecdsa, rsa
-, pycrypto, pytestcov, pytestrunner, cryptography
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, ecdsa
+, rsa
+, pycrypto
+, pyasn1
+, pycryptodome
+, cryptography
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-jose";
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "mpdavis";
-    repo = "python-jose";
+    repo = pname;
     rev = version;
-    sha256 = "cSPIZrps0xFd4pPcQ4w/jFWOk2XYgd3mtE/sDzlytvY=";
+    sha256 = "sha256-6VGC6M5oyGCOiXcYp6mpyhL+JlcYZKIqOQU9Sm/TkKM=";
   };
 
-  checkInputs = [
+  propagatedBuildInputs = [
+    cryptography
+    ecdsa
+    pyasn1
     pycrypto
-    pytestCheckHook
-    pytestcov
-    pytestrunner
-    cryptography # optional dependency, but needed in tests
+    pycryptodome
+    rsa
   ];
 
-  # relax ecdsa deps
-  patchPhase = ''
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
     substituteInPlace setup.py \
-      --replace 'ecdsa<0.15' 'ecdsa' \
-      --replace 'ecdsa <0.15' 'ecdsa'
+      --replace '"pytest-runner",' ""
   '';
 
-  disabledTests = [
-    # https://github.com/mpdavis/python-jose/issues/176
-    "test_key_too_short"
-  ];
-
-  propagatedBuildInputs = [ future six ecdsa rsa ];
+  pythonImportsCheck = [ "jose" ];
 
   meta = with lib; {
     homepage = "https://github.com/mpdavis/python-jose";
     description = "A JOSE implementation in Python";
     license = licenses.mit;
-    maintainers = [ maintainers.jhhuh ];
+    maintainers = with maintainers; [ jhhuh ];
   };
 }

--- a/pkgs/development/python-modules/smart-open/default.nix
+++ b/pkgs/development/python-modules/smart-open/default.nix
@@ -1,39 +1,75 @@
 { lib
 , buildPythonPackage
-, fetchPypi
 , pythonOlder
-, boto
+, fetchFromGitHub
+, azure-common
+, azure-core
+, azure-storage-blob
 , boto3
-, bz2file
-, mock
-, moto
+, google-cloud-storage
 , requests
-, responses
+, moto
+, parameterizedtestcase
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "smart-open";
-  version = "4.2.0";
+  version = "5.1.0";
+
   disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    pname = "smart_open";
-    inherit version;
-    sha256 = "d9f5a0f173ccb9bbae528db5a3804f57145815774f77ef755b9b0f3b4b2a9dcb";
+  src = fetchFromGitHub {
+    owner = "RaRe-Technologies";
+    repo = "smart_open";
+    rev = "v${version}";
+    sha256 = "0gv3vxpglnhh6d80wsqigxi7psn6s7ylz20kx5ahblcx5rqyhjmi";
   };
 
-  # moto>=1.0.0 is backwards-incompatible and some tests fail with it,
-  # so disable tests for now
-  doCheck = false;
+  propagatedBuildInputs = [
+    azure-common
+    azure-core
+    azure-storage-blob
+    boto3
+    google-cloud-storage
+    requests
+  ];
 
-  checkInputs = [ mock moto responses ];
+  checkInputs = [
+    moto
+    parameterizedtestcase
+    pytestCheckHook
+  ];
 
-  # upstream code requires both boto and boto3
-  propagatedBuildInputs = [ boto boto3 bz2file requests ];
+  pytestFlagsArray = [ "smart_open" ];
 
-  meta = {
-    license = lib.licenses.mit;
+  disabledTestPaths = [
+    "smart_open/tests/test_http.py"
+    "smart_open/tests/test_s3.py"
+    "smart_open/tests/test_s3_version.py"
+    "smart_open/tests/test_sanity.py"
+  ];
+
+  disabledTests = [
+    "test_compression_invalid"
+    "test_gs_uri_contains_question_mark"
+    "test_gzip_compress_sanity"
+    "test_http"
+    "test_ignore_ext"
+    "test_initialize_write"
+    "test_read_explicit"
+    "test_s3_handles_querystring"
+    "test_s3_uri_contains_question_mark"
+    "test_webhdfs"
+    "test_write"
+  ];
+
+  pythonImportsCheck = [ "smart_open" ];
+
+  meta = with lib; {
     description = "Library for efficient streaming of very large file";
-    maintainers = with lib.maintainers; [ jyp ];
+    homepage = "https://github.com/RaRe-Technologies/smart_open";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jyp ];
   };
 }

--- a/pkgs/development/python-modules/smart-open/default.nix
+++ b/pkgs/development/python-modules/smart-open/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "smart-open";
-  version = "5.1.0";
+  version = "5.2.0";
 
   disabled = pythonOlder "3.5";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "RaRe-Technologies";
     repo = "smart_open";
     rev = "v${version}";
-    sha256 = "0gv3vxpglnhh6d80wsqigxi7psn6s7ylz20kx5ahblcx5rqyhjmi";
+    sha256 = "sha256-eC9BYHeACzGp382QBNgLcNMYDkHi0WXyEj/Re9ShXuA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/smart-open/default.nix
+++ b/pkgs/development/python-modules/smart-open/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "smart-open";
-  version = "5.2.0";
+  version = "5.2.1";
 
   disabled = pythonOlder "3.5";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "RaRe-Technologies";
     repo = "smart_open";
     rev = "v${version}";
-    sha256 = "sha256-eC9BYHeACzGp382QBNgLcNMYDkHi0WXyEj/Re9ShXuA=";
+    sha256 = "13a1qsb4vwrhx45hz4qcl0d7bgv20ai5vsy7cq0q6qbj212nff19";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -53,9 +53,13 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  # fails to import graphql, but integrated graphql support is about to
-  # be removed in 0.15, see https://github.com/encode/starlette/pull/1135.
-  disabledTestPaths = [ "tests/test_graphql.py" ];
+  disabledTestPaths = [
+    # fails to import graphql, but integrated graphql support is about to
+    # be removed in 0.15, see https://github.com/encode/starlette/pull/1135.
+    "tests/test_graphql.py"
+    # contextfunction was removed in Jinja 3.1
+    "tests/test_templates.py"
+  ];
 
   pythonImportsCheck = [ "starlette" ];
 

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -4,6 +4,8 @@
 , fetchFromGitHub
 , isPy27
 , aiofiles
+, anyio
+, contextlib2
 , graphene
 , itsdangerous
 , jinja2
@@ -12,22 +14,24 @@
 , requests
 , aiosqlite
 , databases
-, pytestCheckHook
 , pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, trio
 , typing-extensions
 , ApplicationServices
 }:
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.14.2";
-  disabled = isPy27;
+  version = "0.16.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "0fz28czvwiww693ig9vwdja59xxs7m0yp1df32ms1hzr99666bia";
+    sha256 = "sha256-/NYhRRZdi6I7CtLCohAqK4prsSUayOxa6sBKIJhPv+w=";
   };
 
   postPatch = ''
@@ -37,19 +41,27 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     aiofiles
+    anyio
     graphene
     itsdangerous
     jinja2
     python-multipart
     pyyaml
     requests
-  ] ++ lib.optional stdenv.isDarwin [ ApplicationServices ];
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    typing-extensions
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    contextlib2
+  ] ++ lib.optional stdenv.isDarwin [
+    ApplicationServices
+  ];
 
   checkInputs = [
     aiosqlite
     databases
     pytest-asyncio
     pytestCheckHook
+    trio
     typing-extensions
   ];
 
@@ -57,8 +69,12 @@ buildPythonPackage rec {
     # fails to import graphql, but integrated graphql support is about to
     # be removed in 0.15, see https://github.com/encode/starlette/pull/1135.
     "tests/test_graphql.py"
-    # contextfunction was removed in Jinja 3.1
-    "tests/test_templates.py"
+  ];
+
+  disabledTests = [
+    # asserts fail due to inclusion of br in Accept-Encoding
+    "test_websocket_headers"
+    "test_request_headers"
   ];
 
   pythonImportsCheck = [ "starlette" ];

--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -1,34 +1,39 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27
+{ lib
+, buildPythonPackage
 , cachetools
 , cytoolz
+, fetchPypi
 , jellyfish
+, joblib
 , matplotlib
 , networkx
 , numpy
 , pyemd
 , pyphen
-, pytest
+, pytestCheckHook
+, pythonOlder
 , requests
 , scikit-learn
 , scipy
 , spacy
-, srsly
+, tqdm
 }:
 
 buildPythonPackage rec {
   pname = "textacy";
-  version = "0.10.1";
-  disabled = isPy27;
+  version = "0.11.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ff72adc6dbb85db6981324e226fff77830da57d7fe7e4adb2cafd9dc2a8bfa7d";
+    sha256 = "sha256-d/tyTCewoERA15iBv4H2LORFzgco15fnnN1sneeGuF4=";
   };
 
   propagatedBuildInputs = [
     cachetools
     cytoolz
     jellyfish
+    joblib
     matplotlib
     networkx
     numpy
@@ -38,22 +43,25 @@ buildPythonPackage rec {
     scikit-learn
     scipy
     spacy
-    srsly
+    tqdm
   ];
 
-  checkInputs = [ pytest ];
-  # almost all tests have to deal with downloading a dataset, only test pure tests
-  checkPhase = ''
-    pytest tests/test_text_utils.py \
-      tests/test_utils.py \
-      tests/preprocessing \
-      tests/datasets/test_base_dataset.py
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    # Almost all tests have to deal with downloading a dataset, only test pure tests
+    "tests/test_constants.py"
+    "tests/preprocessing/test_normalize.py"
+    "tests/similarity/test_edits.py"
+    "tests/preprocessing/test_resources.py"
+    "tests/preprocessing/test_replace.py"
+  ];
+
+  pythonImportsCheck = [ "textacy" ];
 
   meta = with lib; {
-    # scikit-learn in pythonPackages is too new for textacy
-    # remove as soon as textacy support scikit-learn >= 0.24
-    broken = true;
     description = "Higher-level text processing, built on spaCy";
     homepage = "https://textacy.readthedocs.io/";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/typing-extensions/default.nix
+++ b/pkgs/development/python-modules/typing-extensions/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "typing-extensions";
-  version = "4.0.1";
+  version = "4.1.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "typing_extensions";
     inherit version;
-    hash = "sha256-TKCR3qFJ+UXsVq+0ja5xTyHoaS7yKjlSI7zTKJYbag4=";
+    hash = "sha256-GpRi3MM0enmx8cAnH7556ERYC7WYuvoe0gi5TaPNzUI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/typing-extensions/default.nix
+++ b/pkgs/development/python-modules/typing-extensions/default.nix
@@ -1,26 +1,40 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy3k, python, typing }:
-let
-  testDir = if isPy3k then "src_py3" else "src_py2";
+{ lib
+, buildPythonPackage
+, fetchPypi
+, flit-core
+, python
+, pythonOlder
+}:
 
-in buildPythonPackage rec {
-  pname = "typing_extensions";
-  version = "3.10.0.2";
+buildPythonPackage rec {
+  pname = "typing-extensions";
+  version = "4.0.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e";
+    pname = "typing_extensions";
+    inherit version;
+    hash = "sha256-TKCR3qFJ+UXsVq+0ja5xTyHoaS7yKjlSI7zTKJYbag4=";
   };
 
-  checkInputs = lib.optional (pythonOlder "3.5") typing;
+  nativeBuildInputs = [
+    flit-core
+  ];
 
-  # Error for Python3.6: ImportError: cannot import name 'ann_module'
-  # See https://github.com/python/typing/pull/280
-  doCheck = pythonOlder "3.6";
-
-  checkPhase = ''
-    cd ${testDir}
-    ${python.interpreter} -m unittest discover
+  postPatch = ''
+    # Remove metadata for README which are outdated
+    sed -i -e '11,24d' pyproject.toml
   '';
+
+  # Tests are not part of PyPI releases. GitHub source can't be used
+  # as it ends with an infinite recursion
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "typing_extensions"
+  ];
 
   meta = with lib; {
     description = "Backported and Experimental Type Hints for Python 3.5+";

--- a/pkgs/development/python-modules/typing-extensions/default.nix
+++ b/pkgs/development/python-modules/typing-extensions/default.nix
@@ -4,11 +4,11 @@ let
 
 in buildPythonPackage rec {
   pname = "typing_extensions";
-  version = "3.7.4.3";
+  version = "3.10.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c";
+    sha256 = "50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342";
   };
 
   checkInputs = lib.optional (pythonOlder "3.5") typing;

--- a/pkgs/development/python-modules/typing-extensions/default.nix
+++ b/pkgs/development/python-modules/typing-extensions/default.nix
@@ -4,11 +4,11 @@ let
 
 in buildPythonPackage rec {
   pname = "typing_extensions";
-  version = "3.10.0.0";
+  version = "3.10.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342";
+    sha256 = "49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e";
   };
 
   checkInputs = lib.optional (pythonOlder "3.5") typing;

--- a/pkgs/development/python-modules/typing-inspect/default.nix
+++ b/pkgs/development/python-modules/typing-inspect/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "typing-inspect";
-  version = "0.6.0";
+  version = "0.7.1";
 
   src = fetchPypi {
     inherit version;
     pname = "typing_inspect";
-    sha256 = "1dzs9a1pr23dhbvmnvms2jv7l7jk26023g5ysf0zvnq8b791s6wg";
+    sha256 = "1al2lyi3r189r5xgw90shbxvd88ic4si9w7n3d9lczxiv6bl0z84";
   };
 
   propagatedBuildInputs = [
@@ -26,6 +26,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/ilevkivskyi/typing_inspect";
     license = licenses.mit;
     maintainers = with maintainers; [ albakham ];
-    broken = isPy39;  # see https://github.com/ilevkivskyi/typing_inspect/issues/65
   };
 }

--- a/pkgs/development/python-modules/typing-inspect/default.nix
+++ b/pkgs/development/python-modules/typing-inspect/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , typing-extensions
 , mypy-extensions
-, isPy39
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,6 +19,19 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     typing-extensions
     mypy-extensions
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # https://github.com/ilevkivskyi/typing_inspect/issues/84
+    "test_typed_dict_typing_extension"
+  ];
+
+  pythonImportsCheck = [
+    "typing_inspect"
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5050,6 +5050,8 @@ in {
 
   phonenumbers = callPackage ../development/python-modules/phonenumbers { };
 
+  parameterizedtestcase = callPackage ../development/python-modules/parameterizedtestcase { };
+
   phonopy = callPackage ../development/python-modules/phonopy { };
 
   phpserialize = callPackage ../development/python-modules/phpserialize { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4004,8 +4004,9 @@ in {
   };
 
   llvmlite = callPackage ../development/python-modules/llvmlite {
-    llvm = pkgs.llvm_9;
-  }; # llvmlite always requires a specific version of llvm.
+    # llvmlite always requires a specific version of llvm.
+    llvm = pkgs.llvm_11;
+  };
 
   lmdb = callPackage ../development/python-modules/lmdb {
     inherit (pkgs) lmdb;


### PR DESCRIPTION
Backport changes to several packages that are generally incompatible with each other on NixOS/nixpkgs release-21.05

* aiopg
* anyio
* azure-core
* azure-cosmos
* cryptography
* database
* databases
* fastapi
* importlib-resources
* llvmlite
* numba
* parameterizedtestcase
* python-jose
* smart-open
* starlette
* textacy
* typing
* typing-extensions
* typing-inspect
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
