### PR TITLE
nixos/stage-1: add extraUtilsFull package, derive extraUtils from it

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -87,76 +87,89 @@ let
   # copy what we need.  Instead of using statically linked binaries,
   # we just copy what we need from Glibc and use patchelf to make it
   # work.
+  #
+  # Split into two derivations: One containing references to all
+  # inputs and one with nuked references. Do this to get the build
+  # closure of stage1.
+  extraUtilsFull = pkgs.runCommandCC "extra-utils-full" { } ''
+    set +o pipefail
+
+    mkdir -p $out/bin $out/lib
+    ln -s $out/bin $out/sbin
+
+    copy_bin_and_libs () {
+      [ -f "$out/bin/$(basename $1)" ] && rm "$out/bin/$(basename $1)"
+      cp -pdv $1 $out/bin
+    }
+
+    # Copy BusyBox.
+    for BIN in ${pkgs.busybox}/{s,}bin/*; do
+      copy_bin_and_libs $BIN
+    done
+
+    # Copy some utillinux stuff.
+    copy_bin_and_libs ${pkgs.utillinux}/sbin/blkid
+
+    # Copy dmsetup and lvm.
+    copy_bin_and_libs ${getBin pkgs.lvm2}/bin/dmsetup
+    copy_bin_and_libs ${getBin pkgs.lvm2}/bin/lvm
+
+    # Add RAID mdadm tool.
+    copy_bin_and_libs ${pkgs.mdadm}/sbin/mdadm
+    copy_bin_and_libs ${pkgs.mdadm}/sbin/mdmon
+
+    # Copy udev.
+    copy_bin_and_libs ${udev}/bin/udevadm
+    copy_bin_and_libs ${udev}/lib/systemd/systemd-sysctl
+    for BIN in ${udev}/lib/udev/*_id; do
+      copy_bin_and_libs $BIN
+    done
+    # systemd-udevd is only a symlink to udevadm these days
+    ln -sf udevadm $out/bin/systemd-udevd
+
+    # Copy modprobe.
+    copy_bin_and_libs ${pkgs.kmod}/bin/kmod
+    ln -sf kmod $out/bin/modprobe
+
+    # Copy resize2fs if any ext* filesystems are to be resized
+    ${optionalString (any (fs: fs.autoResize && (lib.hasPrefix "ext" fs.fsType)) fileSystems) ''
+      # We need mke2fs in the initrd.
+      copy_bin_and_libs ${pkgs.e2fsprogs}/sbin/resize2fs
+    ''}
+
+    # Copy secrets if needed.
+    #
+    # TODO: move out to a separate script; see #85000.
+    ${optionalString (!config.boot.loader.supportsInitrdSecrets)
+        (concatStringsSep "\n" (mapAttrsToList (dest: source:
+           let source' = if source == null then dest else source; in
+             ''
+                mkdir -p $(dirname "$out/secrets/${dest}")
+                # Some programs (e.g. ssh) doesn't like secrets to be
+                # symlinks, so we use `cp -L` here to match the
+                # behaviour when secrets are natively supported.
+                cp -Lr ${source'} "$out/secrets/${dest}"
+              ''
+        ) config.boot.initrd.secrets))
+     }
+
+    ${config.boot.initrd.extraUtilsCommands}
+
+    # Copy ld manually since it isn't detected correctly
+    cp -pv ${pkgs.stdenv.cc.libc.out}/lib/ld*.so.? $out/lib
+  ''; # */
+
   extraUtils = pkgs.runCommandCC "extra-utils"
-    { nativeBuildInputs = [pkgs.buildPackages.nukeReferences];
+    {
+      nativeBuildInputs = [pkgs.buildPackages.nukeReferences];
       allowedReferences = [ "out" ]; # prevent accidents like glibc being included in the initrd
     }
     ''
       set +o pipefail
 
-      mkdir -p $out/bin $out/lib
-      ln -s $out/bin $out/sbin
+      cp -a ${extraUtilsFull} $out
 
-      copy_bin_and_libs () {
-        [ -f "$out/bin/$(basename $1)" ] && rm "$out/bin/$(basename $1)"
-        cp -pdv $1 $out/bin
-      }
-
-      # Copy BusyBox.
-      for BIN in ${pkgs.busybox}/{s,}bin/*; do
-        copy_bin_and_libs $BIN
-      done
-
-      # Copy some utillinux stuff.
-      copy_bin_and_libs ${pkgs.utillinux}/sbin/blkid
-
-      # Copy dmsetup and lvm.
-      copy_bin_and_libs ${getBin pkgs.lvm2}/bin/dmsetup
-      copy_bin_and_libs ${getBin pkgs.lvm2}/bin/lvm
-
-      # Add RAID mdadm tool.
-      copy_bin_and_libs ${pkgs.mdadm}/sbin/mdadm
-      copy_bin_and_libs ${pkgs.mdadm}/sbin/mdmon
-
-      # Copy udev.
-      copy_bin_and_libs ${udev}/bin/udevadm
-      copy_bin_and_libs ${udev}/lib/systemd/systemd-sysctl
-      for BIN in ${udev}/lib/udev/*_id; do
-        copy_bin_and_libs $BIN
-      done
-      # systemd-udevd is only a symlink to udevadm these days
-      ln -sf udevadm $out/bin/systemd-udevd
-
-      # Copy modprobe.
-      copy_bin_and_libs ${pkgs.kmod}/bin/kmod
-      ln -sf kmod $out/bin/modprobe
-
-      # Copy resize2fs if any ext* filesystems are to be resized
-      ${optionalString (any (fs: fs.autoResize && (lib.hasPrefix "ext" fs.fsType)) fileSystems) ''
-        # We need mke2fs in the initrd.
-        copy_bin_and_libs ${pkgs.e2fsprogs}/sbin/resize2fs
-      ''}
-
-      # Copy secrets if needed.
-      #
-      # TODO: move out to a separate script; see #85000.
-      ${optionalString (!config.boot.loader.supportsInitrdSecrets)
-          (concatStringsSep "\n" (mapAttrsToList (dest: source:
-             let source' = if source == null then dest else source; in
-               ''
-                  mkdir -p $(dirname "$out/secrets/${dest}")
-                  # Some programs (e.g. ssh) doesn't like secrets to be
-                  # symlinks, so we use `cp -L` here to match the
-                  # behaviour when secrets are natively supported.
-                  cp -Lr ${source'} "$out/secrets/${dest}"
-                ''
-          ) config.boot.initrd.secrets))
-       }
-
-      ${config.boot.initrd.extraUtilsCommands}
-
-      # Copy ld manually since it isn't detected correctly
-      cp -pv ${pkgs.stdenv.cc.libc.out}/lib/ld*.so.? $out/lib
+      chmod -R u+w $out
 
       # Copy all of the needed libraries
       find $out/bin $out/lib -type f | while read BIN; do
@@ -171,7 +184,6 @@ let
       done
 
       # Strip binaries further than normal.
-      chmod -R u+w $out
       stripDirs "$STRIP" "lib bin" "-s"
 
       # Run patchelf to make the programs refer to the copied libraries.
@@ -202,8 +214,7 @@ let
 
       ${config.boot.initrd.extraUtilsCommandsTest}
       fi
-    ''; # */
-
+  '';
 
   linkUnits = pkgs.runCommand "link-units" {
       allowedReferences = [ extraUtils ];
@@ -605,8 +616,9 @@ in
       }
     ];
 
-    system.build =
-      { inherit bootStage1 initialRamdisk initialRamdiskSecretAppender extraUtils; };
+    nixpkgs.overlays = [(_: _: { inherit extraUtilsFull; })];
+
+    system.build = { inherit bootStage1 initialRamdisk initialRamdiskSecretAppender extraUtils; };
 
     system.requiredKernelConfig = with config.lib.kernelConfig; [
       (isYes "TMPFS")


### PR DESCRIPTION
To refer to build-build dependencies from system closures.

Since config changes can trigger an initrd rebuild, it may not be
possible to have a 100% offline rebuild without having a cached
version of the extraUtils inputs.

These were impossible to get because the dependencies of extraUtils
are nuked with nukeReferences.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
