### PR TITLE
nixos/nix-daemon: add protocol configuration for buildMachines

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -195,6 +195,13 @@ in
       buildMachines = mkOption {
         type = types.listOf (types.submodule ({
           options = {
+            protocol = mkOption {
+              type = types.enum [ "ssh" "ssh-ng" ];
+              default = "ssh";
+              description = ''
+                The store protocol to use to connect to the builder.
+              '';
+            };
             hostName = mkOption {
               type = types.str;
               example = "nixbuilder.example.org";
@@ -522,7 +529,7 @@ in
       { enable = cfg.buildMachines != [];
         text =
           concatMapStrings (machine:
-            "${if machine.sshUser != null then "${machine.sshUser}@" else ""}${machine.hostName} "
+            "${machine.protocol}://${if machine.sshUser != null then "${machine.sshUser}@" else ""}${machine.hostName} "
             + (if machine.system != null then machine.system else concatStringsSep "," machine.systems)
             + " ${if machine.sshKey != null then machine.sshKey else "-"} ${toString machine.maxJobs} "
             + toString (machine.speedFactor)


### PR DESCRIPTION
To allow users to select ssh or ssh-ng.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
