### PR TITLE
[awake-21.05] fix httplib2 on darwin (backports)

### DIFF
--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -45,7 +45,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = lib.optionals (stdenv.isDarwin) [
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # fails with "ConnectionResetError: [Errno 54] Connection reset by peer"
+    "test_connection_close"
     # fails with HTTP 408 Request Timeout, instead of expected 200 OK
     "test_timeout_subsequent"
   ];

--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , isPy27
 , mock
 , pyparsing
@@ -24,14 +23,6 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "sha256-1zqs3YRVtm5DwewETLtRg5XhMJPJsMi0QLfeGirOURs=";
   };
-
-  patches = [
-    # fix test_inject_space
-    (fetchpatch {
-      url = "https://github.com/httplib2/httplib2/commit/08d6993b69256fbc6c0b1c615c24910803c4d610.patch";
-      sha256 = "0kbd1skn58m20kfkh4qzd66g9bvj31xlkbhsg435dkk4qz6l3yn3";
-    })
-  ];
 
   postPatch = ''
     sed -i "/--cov/d" setup.cfg

--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "httplib2";
-  version = "0.19.1";
+  version = "0.20.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-e0Mq9AVJEWQ9GEtYFXk2fMIs7GtAUsyJN6XheqAnD3I=";
+    sha256 = "sha256-1zqs3YRVtm5DwewETLtRg5XhMJPJsMi0QLfeGirOURs=";
   };
 
   patches = [


### PR DESCRIPTION
To fix test failures on darwin.

Cherry picked from NixOS/nixpkgs release-21.11 ^release-21.05, no merges.