### PR TITLE
gixy: use python3

### DIFF
--- a/pkgs/tools/admin/gixy/default.nix
+++ b/pkgs/tools/admin/gixy/default.nix
@@ -1,11 +1,11 @@
-{ lib, fetchFromGitHub, python }:
+{ lib, fetchFromGitHub, python3 }:
 
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "gixy";
   version = "0.1.20";
 
   # package is only compatible with python 2.7 and 3.5+
-  disabled = with python.pkgs; !(pythonAtLeast "3.5" || isPy27);
+  disabled = with python3.pkgs; !(pythonAtLeast "3.5" || isPy27);
 
   # fetching from GitHub because the PyPi source is missing the tests
   src = fetchFromGitHub {
@@ -19,7 +19,7 @@ python.pkgs.buildPythonApplication rec {
     sed -ie '/argparse/d' setup.py
   '';
 
-  propagatedBuildInputs = with python.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     cached-property
     ConfigArgParse
     pyparsing


### PR DESCRIPTION
(this does not apply to awake-21.05) Backport gixy python dependency update in an effort to reduce closure size.