### PR TITLE
[21.05] binutils: backport performance/regression fixes.

### DIFF
--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -203,6 +203,7 @@ let
     "tests/jobs/test_scheduler_job.py::TestSchedulerJob::test_retry_still_in_executor"
     "tests/operators/test_bash.py::TestBashOperator::test_bash_operator_kill"
     "tests/utils/test_process_utils.py::TestCheckIfPidfileProcessIsRunning::test_remove_if_no_process"
+    "tests/utils/test_dates.py::TestDates::test_days_ago"
   ];
 
 in

--- a/pkgs/development/python-modules/sh/disable-broken-tests-darwin.patch
+++ b/pkgs/development/python-modules/sh/disable-broken-tests-darwin.patch
@@ -4,15 +4,9 @@ Date: Mon, 20 Jul 2020 19:51:20 +0200
 Subject: [PATCH] Disable tests that fail on Darwin (macOS) or with sandboxing
 
 Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>
----
- test.py | 4 ++++
- 1 file changed, 4 insertions(+)
-
-diff --git a/test.py b/test.py
-index f8029c0..ba1d141 100644
 --- a/test.py
 +++ b/test.py
-@@ -404,6 +404,7 @@ exit(3)
+@@ -377,6 +377,7 @@ exit(3)
          self.assertEqual(sed(_in="one test three", e="s/test/two/").strip(),
                           "one two three")
  
@@ -20,7 +14,7 @@ index f8029c0..ba1d141 100644
      def test_ok_code(self):
          from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
  
-@@ -1004,6 +1005,7 @@ print(sys.argv[1])
+@@ -982,6 +983,7 @@ print(sys.argv[1])
          now = time.time()
          self.assertGreater(now - start, sleep_time)
  
@@ -28,7 +22,7 @@ index f8029c0..ba1d141 100644
      def test_background_exception(self):
          from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
          p = ls("/ofawjeofj", _bg=True, _bg_exc=False)  # should not raise
-@@ -1801,6 +1803,7 @@ exit(49)
+@@ -1779,6 +1781,7 @@ exit(49)
          p = python(py.name, _ok_code=49, _bg=True)
          self.assertEqual(49, p.exit_code)
  
@@ -36,7 +30,15 @@ index f8029c0..ba1d141 100644
      def test_cwd(self):
          from sh import pwd
          from os.path import realpath
-@@ -2899,6 +2902,7 @@ print("hi")
+@@ -2777,6 +2780,7 @@ print("cool")
+     # on osx.  so skip it for now if osx
+     @not_macos
+     @requires_progs("lsof")
++    @skipUnless(False, "Flaky on Hydra")
+     def test_no_fd_leak(self):
+         import sh
+         import os
+@@ -2879,6 +2883,7 @@ print("hi")
          python(py.name, _in=stdin)
  
      @requires_utf8
@@ -44,6 +46,3 @@ index f8029c0..ba1d141 100644
      def test_unicode_path(self):
          from sh import Command
  
--- 
-2.27.0
-

--- a/pkgs/development/tools/misc/binutils/bfd-elf-Dont-read-non-existing-secondary-relocs.patch
+++ b/pkgs/development/tools/misc/binutils/bfd-elf-Dont-read-non-existing-secondary-relocs.patch
@@ -1,0 +1,26 @@
+X-Git-Url: https://sourceware.org/git/?p=binutils-gdb.git;a=blobdiff_plain;f=bfd%2Felf.c;h=af62aadc3d446cd5b1f0201b207c90c22e7809b1;hp=36733e080dd9d9be28b576b246aaf5bd8c8569c7;hb=84fd26d8209e99fc3a432dd0b09b6c053de1ce65;hpb=abe2a28aaa7a2bfd0f3061c72a98eb898976b721
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index 36733e080dd..af62aadc3d4 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -2454,6 +2454,8 @@ bfd_section_from_shdr (bfd *abfd, unsigned int shindex)
+ 		     "for section %pA found - ignoring"),
+ 		   abfd, name, target_sect);
+ 	      }
++	    else
++	      esdt->has_secondary_relocs = TRUE;
+ 	    goto success;
+ 	  }
+ 
+@@ -12587,6 +12589,9 @@ _bfd_elf_slurp_secondary_reloc_section (bfd *       abfd,
+ #endif
+     r_sym = elf32_r_sym;
+   
++  if (!elf_section_data (sec)->has_secondary_relocs)
++    return TRUE;
++
+   /* Discover if there are any secondary reloc sections
+      associated with SEC.  */
+   for (relsec = abfd->sections; relsec != NULL; relsec = relsec->next)
+

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -61,6 +61,15 @@ stdenv.mkDerivation {
     # cross-compiling.
     ./always-search-rpath.patch
 
+    # Fix quadratic slowdown in `strip` performance.
+    # See #129467 and https://sourceware.org/bugzilla/show_bug.cgi?id=28058
+    # Remove when we're on binutils > 2.36.1.
+    # The patch is downloaded from
+    #     https://sourceware.org/git/?p=binutils-gdb.git;a=blobdiff_plain;f=bfd/elf.c;h=af62aadc3d446cd5b1f0201b207c90c22e7809b1;hp=36733e080dd9d9be28b576b246aaf5bd8c8569c7;hb=84fd26d8209e99fc3a432dd0b09b6c053de1ce65;hpb=abe2a28aaa7a2bfd0f3061c72a98eb898976b721
+    # which is the 2.36 backport (using `TRUE` instead of `true` of binutils master commit:
+    #     https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=956ea65cd707707c0f725930214cbc781367a831
+    ./bfd-elf-Dont-read-non-existing-secondary-relocs.patch
+
     ./CVE-2020-35448.patch
     ./CVE-2021-3487.patch
     ./CVE-2021-45078.patch

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -70,6 +70,11 @@ stdenv.mkDerivation {
     #     https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=956ea65cd707707c0f725930214cbc781367a831
     ./bfd-elf-Dont-read-non-existing-secondary-relocs.patch
 
+    # Fix building plv8’s v8.
+    # https://github.com/NixOS/nixpkgs/issues/134190
+    # Obtained from: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=586e30940e640f67bd55bd72e1d1355a4faf8079
+    ./gold-Update-GNU_PROPERTY_X86_XXX-macros.patch
+
     ./CVE-2020-35448.patch
     ./CVE-2021-3487.patch
     ./CVE-2021-45078.patch

--- a/pkgs/development/tools/misc/binutils/gold-Update-GNU_PROPERTY_X86_XXX-macros.patch
+++ b/pkgs/development/tools/misc/binutils/gold-Update-GNU_PROPERTY_X86_XXX-macros.patch
@@ -1,0 +1,292 @@
+From 586e30940e640f67bd55bd72e1d1355a4faf8079 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Tue, 13 Oct 2020 05:20:49 -0700
+Subject: [PATCH] gold: Update GNU_PROPERTY_X86_XXX macros
+
+This patch updates GNU_PROPERTY_X86_XXX macros for gold:
+
+1. GNU_PROPERTY_X86_UINT32_AND_XXX: A 4-byte unsigned integer property.
+A bit is set if it is set in all relocatable inputs:
+
+ #define GNU_PROPERTY_X86_UINT32_AND_LO      0xc0000002
+ #define GNU_PROPERTY_X86_UINT32_AND_HI      0xc0007fff
+
+2. GNU_PROPERTY_X86_UINT32_OR_XXX: A 4-byte unsigned integer property.
+A bit is set if it is set in any relocatable inputs:
+
+ #define GNU_PROPERTY_X86_UINT32_OR_LO    0xc0008000
+ #define GNU_PROPERTY_X86_UINT32_OR_HI    0xc000ffff
+
+3. GNU_PROPERTY_X86_UINT32_OR_AND_XXX: A 4-byte unsigned integer property.
+A bit is set if it is set in any relocatable inputs and the property is
+present in all relocatable inputs:
+
+ #define GNU_PROPERTY_X86_UINT32_OR_AND_LO   0xc0010000
+ #define GNU_PROPERTY_X86_UINT32_OR_AND_HI   0xc0017fff
+
+4. GNU_PROPERTY_X86_FEATURE_2_NEEDED, GNU_PROPERTY_X86_FEATURE_2_USED
+and GNU_PROPERTY_X86_FEATURE_2_XXX bits.
+
+GNU_PROPERTY_X86_FEATURE_1_AND is unchanged.  GNU_PROPERTY_X86_ISA_1_USED
+and GNU_PROPERTY_X86_ISA_1_NEEDED are updated to better support targeted
+processors since GNU_PROPERTY_X86_ISA_1_?86 aren't isn't very useful.
+A new set of GNU_PROPERTY_X86_ISA_1_XXX bits are defined.  The previous
+GNU_PROPERTY_X86_ISA_1_XXX macros are deprecated and renamed to
+GNU_PROPERTY_X86_COMPAT_ISA_1_XXX and GNU_PROPERTY_X86_COMPAT_2_ISA_1_XXX.
+
+elfcpp/
+
+	* elfcpp.h (GNU_PROPERTY_X86_ISA_1_USED): Renamed to ...
+	(GNU_PROPERTY_X86_COMPAT_ISA_1_USED): This.
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): Renamed to ...
+	(GNU_PROPERTY_X86_COMPAT_ISA_1_NEEDED): This.
+	(GNU_PROPERTY_X86_UINT32_AND_LO): New.
+	(GNU_PROPERTY_X86_UINT32_AND_HI): Likewise.
+	(GNU_PROPERTY_X86_UINT32_OR_LO): Likewise.
+	(GNU_PROPERTY_X86_UINT32_OR_HI): Likewise.
+	(GNU_PROPERTY_X86_UINT32_OR_AND_LO): Likewise.
+	(GNU_PROPERTY_X86_UINT32_OR_AND_HI): Likewise.
+	(GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED): New.
+	(GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED): Likewise.
+	(GNU_PROPERTY_X86_FEATURE_1_AND): Updated to
+	(GNU_PROPERTY_X86_UINT32_AND_LO + 0).
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): New.  Defined to
+	GNU_PROPERTY_X86_UINT32_OR_LO + 2.
+	(GNU_PROPERTY_X86_FEATURE_2_NEEDED): New.  Defined to
+	(GNU_PROPERTY_X86_UINT32_OR_LO + 1).
+	(GNU_PROPERTY_X86_ISA_1_USED): New.  Defined to
+	GNU_PROPERTY_X86_UINT32_OR_AND_LO + 2.
+	(GNU_PROPERTY_X86_FEATURE_2_USED): New.  Defined to
+	(GNU_PROPERTY_X86_UINT32_OR_AND_LO + 1).
+
+gold/
+
+	* x86_64.cc (Target_x86_64::Target_x86_64): Initialize
+	feature_2_used_, feature_2_needed_ and object_feature_2_used_.
+	(Target_x86_64::feature_2_used_): New data member.
+	(Target_x86_64::feature_2_needed_): Likewise.
+	(Target_x86_64::object_isa_1_used_): Likewise.
+	(Target_x86_64::record_gnu_property): Support
+	GNU_PROPERTY_X86_COMPAT_ISA_1_USED,
+	GNU_PROPERTY_X86_COMPAT_ISA_1_NEEDED,
+	GNU_PROPERTY_X86_COMPAT_2_ISA_1_USED,
+	GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED,
+	GNU_PROPERTY_X86_FEATURE_2_USED and
+	GNU_PROPERTY_X86_FEATURE_2_NEEDED.
+	(Target_x86_64::merge_gnu_properties): Merge FEATURE_2_USED bits.
+	Initialize object_feature_2_used_.
+	(Target_x86_64::do_finalize_gnu_properties): Support
+	GNU_PROPERTY_X86_FEATURE_2_USED and
+	GNU_PROPERTY_X86_FEATURE_2_NEEDED.
+	* testsuite/gnu_property_a.S (GNU_PROPERTY_X86_ISA_1_USED): Set
+	to 0xc0010002.
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): Set to 0xc0008002.
+	* testsuite/gnu_property_b.S (GNU_PROPERTY_X86_ISA_1_USED): Set
+	to 0xc0010002.
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): Set to 0xc0008002.
+	* testsuite/gnu_property_c.S (GNU_PROPERTY_X86_ISA_1_USED): Set
+	to 0xc0010002.
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): Set to 0xc0008002.
+	* testsuite/gnu_property_test.sh: Updated.
+---
+ elfcpp/ChangeLog                    | [omitted]
+ elfcpp/elfcpp.h                     | 18 ++++++++++++---
+ gold/ChangeLog                      | [omitted]
+ gold/testsuite/gnu_property_a.S     |  4 ++--
+ gold/testsuite/gnu_property_b.S     |  4 ++--
+ gold/testsuite/gnu_property_c.S     |  4 ++--
+ gold/testsuite/gnu_property_test.sh |  4 ++--
+ gold/x86_64.cc                      | 34 +++++++++++++++++++++++++++--
+ 8 files changed, 110 insertions(+), 13 deletions(-)
+
+diff --git a/elfcpp/elfcpp.h b/elfcpp/elfcpp.h
+index 65d803c00e2..4b6ff94a654 100644
+--- a/elfcpp/elfcpp.h
++++ b/elfcpp/elfcpp.h
+@@ -1013,9 +1013,21 @@ enum
+   GNU_PROPERTY_STACK_SIZE = 1,
+   GNU_PROPERTY_NO_COPY_ON_PROTECTED = 2,
+   GNU_PROPERTY_LOPROC = 0xc0000000,
+-  GNU_PROPERTY_X86_ISA_1_USED = 0xc0000000,
+-  GNU_PROPERTY_X86_ISA_1_NEEDED = 0xc0000001,
+-  GNU_PROPERTY_X86_FEATURE_1_AND = 0xc0000002,
++  GNU_PROPERTY_X86_COMPAT_ISA_1_USED = 0xc0000000,
++  GNU_PROPERTY_X86_COMPAT_ISA_1_NEEDED = 0xc0000001,
++  GNU_PROPERTY_X86_UINT32_AND_LO = 0xc0000002,
++  GNU_PROPERTY_X86_UINT32_AND_HI = 0xc0007fff,
++  GNU_PROPERTY_X86_UINT32_OR_LO = 0xc0008000,
++  GNU_PROPERTY_X86_UINT32_OR_HI = 0xc000ffff,
++  GNU_PROPERTY_X86_UINT32_OR_AND_LO = 0xc0010000,
++  GNU_PROPERTY_X86_UINT32_OR_AND_HI = 0xc0017fff,
++  GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED = GNU_PROPERTY_X86_UINT32_OR_LO + 0,
++  GNU_PROPERTY_X86_COMPAT_2_ISA_1_USED = GNU_PROPERTY_X86_UINT32_OR_AND_LO + 0,
++  GNU_PROPERTY_X86_FEATURE_1_AND = GNU_PROPERTY_X86_UINT32_AND_LO + 0,
++  GNU_PROPERTY_X86_ISA_1_NEEDED = GNU_PROPERTY_X86_UINT32_OR_LO + 2,
++  GNU_PROPERTY_X86_FEATURE_2_NEEDED = GNU_PROPERTY_X86_UINT32_OR_LO + 1,
++  GNU_PROPERTY_X86_ISA_1_USED = GNU_PROPERTY_X86_UINT32_OR_AND_LO + 2,
++  GNU_PROPERTY_X86_FEATURE_2_USED = GNU_PROPERTY_X86_UINT32_OR_AND_LO + 1,
+   GNU_PROPERTY_HIPROC = 0xdfffffff,
+   GNU_PROPERTY_LOUSER = 0xe0000000,
+   GNU_PROPERTY_HIUSER = 0xffffffff
+diff --git a/gold/testsuite/gnu_property_a.S b/gold/testsuite/gnu_property_a.S
+index 463bc8e52fe..5fbbbc9c4bb 100644
+--- a/gold/testsuite/gnu_property_a.S
++++ b/gold/testsuite/gnu_property_a.S
+@@ -1,8 +1,8 @@
+ #define NT_GNU_PROPERTY_TYPE_0 5
+ 
+ #define GNU_PROPERTY_STACK_SIZE 1
+-#define GNU_PROPERTY_X86_ISA_1_USED 0xc0000000
+-#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0000001
++#define GNU_PROPERTY_X86_ISA_1_USED 0xc0010002
++#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0008002
+ #define GNU_PROPERTY_X86_FEATURE_1_AND 0xc0000002
+ 
+ #if __SIZEOF_PTRDIFF_T__  == 8
+diff --git a/gold/testsuite/gnu_property_b.S b/gold/testsuite/gnu_property_b.S
+index 0c0c038ead1..7028f73d7ab 100644
+--- a/gold/testsuite/gnu_property_b.S
++++ b/gold/testsuite/gnu_property_b.S
+@@ -2,8 +2,8 @@
+ 
+ #define GNU_PROPERTY_STACK_SIZE 1
+ #define GNU_PROPERTY_NO_COPY_ON_PROTECTED 2
+-#define GNU_PROPERTY_X86_ISA_1_USED 0xc0000000
+-#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0000001
++#define GNU_PROPERTY_X86_ISA_1_USED 0xc0010002
++#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0008002
+ #define GNU_PROPERTY_X86_FEATURE_1_AND 0xc0000002
+ 
+ #if __SIZEOF_PTRDIFF_T__  == 8
+diff --git a/gold/testsuite/gnu_property_c.S b/gold/testsuite/gnu_property_c.S
+index ace159a9a9d..c8cbd8bce28 100644
+--- a/gold/testsuite/gnu_property_c.S
++++ b/gold/testsuite/gnu_property_c.S
+@@ -2,8 +2,8 @@
+ 
+ #define GNU_PROPERTY_STACK_SIZE 1
+ #define GNU_PROPERTY_NO_COPY_ON_PROTECTED 2
+-#define GNU_PROPERTY_X86_ISA_1_USED 0xc0000000
+-#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0000001
++#define GNU_PROPERTY_X86_ISA_1_USED 0xc0010002
++#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0008002
+ #define GNU_PROPERTY_X86_FEATURE_1_AND 0xc0000002
+ 
+ #if __SIZEOF_PTRDIFF_T__  == 8
+diff --git a/gold/testsuite/gnu_property_test.sh b/gold/testsuite/gnu_property_test.sh
+index 1806d3474cc..a4096005b78 100755
+--- a/gold/testsuite/gnu_property_test.sh
++++ b/gold/testsuite/gnu_property_test.sh
+@@ -77,8 +77,8 @@ check_count gnu_property_test.stdout "^  NOTE" 2
+ 
+ check gnu_property_test.stdout "stack size: 0x111100"
+ check gnu_property_test.stdout "no copy on protected"
+-check gnu_property_test.stdout "x86 ISA used: i486, SSE2, SSE4_2, AVX512CD"
+-check gnu_property_test.stdout "x86 ISA needed: i486, SSE2, SSE4_2, AVX512CD"
++check gnu_property_test.stdout "x86 ISA used: x86-64-v2, <unknown: 10>, <unknown: 100>, <unknown: 1000>"
++check gnu_property_test.stdout "x86 ISA needed: x86-64-v2, <unknown: 10>, <unknown: 100>, <unknown: 1000>"
+ check gnu_property_test.stdout "x86 feature: IBT"
+ 
+ exit 0
+diff --git a/gold/x86_64.cc b/gold/x86_64.cc
+index 9cb2cf0a322..378bac16f78 100644
+--- a/gold/x86_64.cc
++++ b/gold/x86_64.cc
+@@ -706,8 +706,9 @@ class Target_x86_64 : public Sized_target<size, false>
+       rela_irelative_(NULL), copy_relocs_(elfcpp::R_X86_64_COPY),
+       got_mod_index_offset_(-1U), tlsdesc_reloc_info_(),
+       tls_base_symbol_defined_(false), isa_1_used_(0), isa_1_needed_(0),
+-      feature_1_(0), object_isa_1_used_(0), object_feature_1_(0),
+-      seen_first_object_(false)
++      feature_1_(0), feature_2_used_(0), feature_2_needed_(0),
++      object_isa_1_used_(0), object_feature_1_(0),
++      object_feature_2_used_(0), seen_first_object_(false)
+   { }
+ 
+   // Hook for a new output section.
+@@ -1382,6 +1383,8 @@ class Target_x86_64 : public Sized_target<size, false>
+   uint32_t isa_1_used_;
+   uint32_t isa_1_needed_;
+   uint32_t feature_1_;
++  uint32_t feature_2_used_;
++  uint32_t feature_2_needed_;
+   // Target-specific properties from the current object.
+   // These bits get ORed into ISA_1_USED_ after all properties for the object
+   // have been processed. But if either is all zeroes (as when the property
+@@ -1391,6 +1394,7 @@ class Target_x86_64 : public Sized_target<size, false>
+   // These bits get ANDed into FEATURE_1_ after all properties for the object
+   // have been processed.
+   uint32_t object_feature_1_;
++  uint32_t object_feature_2_used_;
+   // Whether we have seen our first object, for use in initializing FEATURE_1_.
+   bool seen_first_object_;
+ };
+@@ -1594,9 +1598,15 @@ Target_x86_64<size>::record_gnu_property(
+ 
+   switch (pr_type)
+     {
++    case elfcpp::GNU_PROPERTY_X86_COMPAT_ISA_1_USED:
++    case elfcpp::GNU_PROPERTY_X86_COMPAT_ISA_1_NEEDED:
++    case elfcpp::GNU_PROPERTY_X86_COMPAT_2_ISA_1_USED:
++    case elfcpp::GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED:
+     case elfcpp::GNU_PROPERTY_X86_ISA_1_USED:
+     case elfcpp::GNU_PROPERTY_X86_ISA_1_NEEDED:
+     case elfcpp::GNU_PROPERTY_X86_FEATURE_1_AND:
++    case elfcpp::GNU_PROPERTY_X86_FEATURE_2_USED:
++    case elfcpp::GNU_PROPERTY_X86_FEATURE_2_NEEDED:
+       if (pr_datasz != 4)
+ 	{
+ 	  gold_warning(_("%s: corrupt .note.gnu.property section "
+@@ -1625,6 +1635,12 @@ Target_x86_64<size>::record_gnu_property(
+       // If we see multiple feature props in one object, OR them together.
+       this->object_feature_1_ |= val;
+       break;
++    case elfcpp::GNU_PROPERTY_X86_FEATURE_2_USED:
++      this->object_feature_2_used_ |= val;
++      break;
++    case elfcpp::GNU_PROPERTY_X86_FEATURE_2_NEEDED:
++      this->feature_2_needed_ |= val;
++      break;
+     }
+ }
+ 
+@@ -1642,15 +1658,23 @@ Target_x86_64<size>::merge_gnu_properties(const Object*)
+       else if (this->isa_1_used_ != 0)
+ 	this->isa_1_used_ |= this->object_isa_1_used_;
+       this->feature_1_ &= this->object_feature_1_;
++      // If any object is missing the FEATURE_2_USED property, we must
++      // omit it from the output file.
++      if (this->object_feature_2_used_ == 0)
++	this->feature_2_used_ = 0;
++      else if (this->feature_2_used_ != 0)
++	this->feature_2_used_ |= this->object_feature_2_used_;
+     }
+   else
+     {
+       this->isa_1_used_ = this->object_isa_1_used_;
+       this->feature_1_ = this->object_feature_1_;
++      this->feature_2_used_ = this->object_feature_2_used_;
+       this->seen_first_object_ = true;
+     }
+   this->object_isa_1_used_ = 0;
+   this->object_feature_1_ = 0;
++  this->object_feature_2_used_ = 0;
+ }
+ 
+ static inline void
+@@ -1676,6 +1700,12 @@ Target_x86_64<size>::do_finalize_gnu_properties(Layout* layout) const
+   if (this->feature_1_ != 0)
+     add_property(layout, elfcpp::GNU_PROPERTY_X86_FEATURE_1_AND,
+ 		 this->feature_1_);
++  if (this->feature_2_used_ != 0)
++    add_property(layout, elfcpp::GNU_PROPERTY_X86_FEATURE_2_USED,
++		 this->feature_2_used_);
++  if (this->feature_2_needed_ != 0)
++    add_property(layout, elfcpp::GNU_PROPERTY_X86_FEATURE_2_NEEDED,
++		 this->feature_2_needed_);
+ }
+ 
+ // Write the first three reserved words of the .got.plt section.
+-- 
+2.27.0
+


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/129900 and https://github.com/NixOS/nixpkgs/pull/134195 to fix `strip` performance regression and ghc linkage fallout.