### PR TITLE
[21.05] nixos/self-deploy: backport fixes from upstream.

### DIFF
--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -126,9 +126,9 @@ in
 
   config = lib.mkIf cfg.enable {
     systemd.services.self-deploy = {
-      wantedBy = [ "multi-user.target" ];
+      inherit (cfg) startAt;
 
-      startAt = cfg.startAt;
+      wantedBy = [ "multi-user.target" ];
 
       requires = lib.mkIf (!(isPathType cfg.repository)) [ "network-online.target" ];
 
@@ -142,8 +142,7 @@ in
         gnutar
         gzip
         nix
-        systemd
-      ];
+      ] ++ lib.optionals (cfg.switchCommand == "boot") [ systemd ];
 
       script = ''
         if [ ! -e ${repositoryDirectory} ]; then

--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -128,6 +128,8 @@ in
     systemd.services.self-deploy = {
       wantedBy = [ "multi-user.target" ];
 
+      startAt = cfg.startAt;
+
       requires = lib.mkIf (!(isPathType cfg.repository)) [ "network-online.target" ];
 
       environment.GIT_SSH_COMMAND = lib.mkIf (!(isNull cfg.sshKeyFile))

--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -37,7 +37,9 @@ in
     };
 
     nixAttribute = lib.mkOption {
-      type = lib.types.str;
+      type = with lib.types; nullOr str;
+
+      default = null;
 
       description = ''
         Attribute of `nixFile` that builds the current system.


### PR DESCRIPTION
Primarily to install the timer alongside the service.