### PR TITLE
writeShellApplication-backport

### DIFF
--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -47,6 +47,28 @@ These functions write `text` to the Nix store. This is useful for creating scrip
 
 Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `writeScript`, and `writeScriptBin`. These are convenience functions over `writeTextFile`.
 
+## `writeShellApplication` {#trivial-builder-writeShellApplication}
+
+This can be used to easily produce a shell script that has some dependencies (`buildInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).
+
+For example, look at the following code:
+
+```nix
+writeShellApplication {
+  name = "show-nixos-org";
+
+  buildInputs = [ curl w3m ];
+
+  text = ''
+    curl -s 'https://nixos.org' | w3m -dump -T text/html
+  '';
+}
+```
+
+Unlike with normal `writeShellScriptBin`, there is no need to manually write out `${curl}/bin/curl`, setting the PATH
+was handled by `writeShellApplication`. Moreover, the script is being checked with `shellcheck` for more strict
+validation.
+
 ## `symlinkJoin` {#trivial-builder-symlinkJoin}
 
 This can be used to put many derivations into the same directory structure. It works by creating a new derivation and adding symlinks to each of the paths listed. It expects two arguments, `name`, and `paths`. `name` is the name used in the Nix store path for the created derivation. `paths` is a list of paths that will be symlinked. These paths can be to Nix store derivations or any other subdirectory contained within.

--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -49,7 +49,7 @@ Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `
 
 ## `writeShellApplication` {#trivial-builder-writeShellApplication}
 
-This can be used to easily produce a shell script that has some dependencies (`buildInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).
+This can be used to easily produce a shell script that has some dependencies (`runtimeInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).
 
 For example, look at the following code:
 
@@ -57,7 +57,7 @@ For example, look at the following code:
 writeShellApplication {
   name = "show-nixos-org";
 
-  buildInputs = [ curl w3m ];
+  runtimeInputs = [ curl w3m ];
 
   text = ''
     curl -s 'https://nixos.org' | w3m -dump -T text/html

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -259,6 +259,10 @@ rec {
    * Automatically includes sane set of shellopts (errexit, nounset, pipefail)
    * and handles creation of PATH based on runtimeInputs
    *
+   * Note that the checkPhase uses stdenv.shell for the test run of the script,
+   * while the generated shebang uses runtimeShell. If, for whatever reason,
+   * those were to mismatch you might lose fidelity in the default checks.
+   *
    * Example:
    * # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
    * writeShellApplication {

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -290,8 +290,10 @@ rec {
         set -o errexit
         set -o nounset
         set -o pipefail
+      '' + lib.optionalString (runtimeInputs != [ ]) ''
 
         export PATH="${lib.makeBinPath runtimeInputs}:$PATH"
+      '' + ''
 
         ${text}
       '';

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -114,9 +114,11 @@ rec {
     , executable ? false # run chmod +x ?
     , destination ? ""   # relative path appended to $out eg "/bin/foo"
     , checkPhase ? ""    # syntax checks, e.g. for scripts
+    , meta ? { }
     }:
     runCommand name
       { inherit text executable;
+      { inherit text executable checkPhase meta;
         passAsFile = [ "text" ];
         # Pointless to do this on a remote machine.
         preferLocalBuild = true;

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, makeBinPath, shellcheck }:
+{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, shellcheck }:
 
 rec {
 
@@ -285,7 +285,7 @@ rec {
         set -o nounset
         set- o pipefail
 
-        export PATH="${makeBinPath runtimeInputs}:$PATH"
+        export PATH="${lib.makeBinPath runtimeInputs}:$PATH"
 
         ${text}
       '';

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -263,7 +263,7 @@ rec {
    * # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
    * writeShellApplication {
    *   name = "my-file";
-   *   buildInputs = [ curl w3m ];
+   *   runtimeInputs = [ curl w3m ];
    *   text = ''
    *     curl -s 'https://nixos.org' | w3m -dump -T text/html
    *    '';
@@ -272,7 +272,7 @@ rec {
   writeShellApplication =
     { name
     , text
-    , buildInputs ? [ ]
+    , runtimeInputs ? [ ]
     , checkPhase ? null
     }:
     writeTextFile {
@@ -285,7 +285,7 @@ rec {
         set -o nounset
         set- o pipefail
 
-        export PATH="${makeBinPath buildInputs}:$PATH"
+        export PATH="${makeBinPath runtimeInputs}:$PATH"
 
         ${text}
       '';

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -283,7 +283,7 @@ rec {
         #!${runtimeShell}
         set -o errexit
         set -o nounset
-        set- o pipefail
+        set -o pipefail
 
         export PATH="${lib.makeBinPath runtimeInputs}:$PATH"
 

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -295,8 +295,10 @@ rec {
       '';
 
       checkPhase = if checkPhase == null then ''
+        runHook preCheck
         ${stdenv.shell} -n $out/bin/${name}
         ${shellcheck}/bin/shellcheck $out/bin/${name}
+        runHook postCheck
       ''
       else checkPhase;
     };

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -257,7 +257,7 @@ rec {
    * Writes an executable Shell script to /nix/store/<store path>/bin/<name> and
    * checks its syntax with shellcheck and the shell's -n option.
    * Automatically includes sane set of shellopts (errexit, nounset, pipefail)
-   * and handles creation of PATH based on buildInputs
+   * and handles creation of PATH based on runtimeInputs
    *
    * Example:
    * # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, stdenvNoCC, lndir, runtimeShell }:
+{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, makeBinPath, shellcheck }:
 
 rec {
 
@@ -250,6 +250,51 @@ rec {
       checkPhase = ''
         ${stdenv.shell} -n $out/bin/${name}
       '';
+    };
+
+  /*
+   * Similar to writeShellScriptBin and writeScriptBin.
+   * Writes an executable Shell script to /nix/store/<store path>/bin/<name> and
+   * checks its syntax with shellcheck and the shell's -n option.
+   * Automatically includes sane set of shellopts (errexit, nounset, pipefail)
+   * and handles creation of PATH based on buildInputs
+   *
+   * Example:
+   * # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
+   * writeShellApplication {
+   *   name = "my-file";
+   *   buildInputs = [ curl w3m ];
+   *   text = ''
+   *     curl -s 'https://nixos.org' | w3m -dump -T text/html
+   *    '';
+   * }
+  */
+  writeShellApplication =
+    { name
+    , text
+    , buildInputs ? [ ]
+    , checkPhase ? null
+    }:
+    writeTextFile {
+      inherit name;
+      executable = true;
+      destination = "/bin/${name}";
+      text = ''
+        #!${runtimeShell}
+        set -o errexit
+        set -o nounset
+        set- o pipefail
+
+        export PATH="${makeBinPath buildInputs}:$PATH"
+
+        ${text}
+      '';
+
+      checkPhase = if checkPhase == null then ''
+        ${stdenv.shell} -n $out/bin/${name}
+        ${shellcheck}/bin/shellcheck $out/bin/${name}
+      ''
+      else checkPhase;
     };
 
   # Create a C binary

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -296,13 +296,16 @@ rec {
         ${text}
       '';
 
-      checkPhase = if checkPhase == null then ''
-        runHook preCheck
-        ${stdenv.shell} -n $out/bin/${name}
-        ${shellcheck}/bin/shellcheck $out/bin/${name}
-        runHook postCheck
-      ''
-      else checkPhase;
+      checkPhase =
+        if checkPhase == null then ''
+          runHook preCheck
+          ${stdenv.shell} -n $out/bin/${name}
+          ${shellcheck}/bin/shellcheck $out/bin/${name}
+          runHook postCheck
+        ''
+        else checkPhase;
+
+      meta.mainProgram = name;
     };
 
   # Create a C binary

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -71,7 +71,9 @@ let
 
   trivialBuilders = self: super:
     import ../build-support/trivial-builders.nix {
-      inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.pkgsBuildHost.xorg) lndir;
+      inherit lib; inherit (self) stdenv stdenvNoCC;
+      inherit (self.pkgsBuildHost) shellcheck;
+      inherit (self.pkgsBuildHost.xorg) lndir;
       inherit (self) runtimeShell;
     };
 


### PR DESCRIPTION
Backport of writeShellApplication to awake 21.05

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
