### PR TITLE
Added before for grafana in grafana-image-renderer.nix

### DIFF
--- a/nixos/modules/services/monitoring/grafana-image-renderer.nix
+++ b/nixos/modules/services/monitoring/grafana-image-renderer.nix
@@ -111,6 +111,7 @@ in {
     services.grafana.extraOptions = mkIf cfg.provisionGrafana {
       RENDERING_SERVER_URL = "http://localhost:${toString cfg.settings.service.port}/render";
       RENDERING_CALLBACK_URL = "http://localhost:${toString config.services.grafana.port}";
+      before = [ "grafana-image-renderer.service" ];
     };
 
     services.grafana-image-renderer.chromium = mkDefault pkgs.chromium;

--- a/nixos/modules/services/monitoring/grafana-image-renderer.nix
+++ b/nixos/modules/services/monitoring/grafana-image-renderer.nix
@@ -111,8 +111,9 @@ in {
     services.grafana.extraOptions = mkIf cfg.provisionGrafana {
       RENDERING_SERVER_URL = "http://localhost:${toString cfg.settings.service.port}/render";
       RENDERING_CALLBACK_URL = "http://localhost:${toString config.services.grafana.port}";
-      before = [ "grafana-image-renderer.service" ];
     };
+
+    systemd.services.grafana.before = [ "grafana-image-renderer.service" ];
 
     services.grafana-image-renderer.chromium = mkDefault pkgs.chromium;
 


### PR DESCRIPTION
Add the before of grafana in grafana-image-renderer.nix, with this change, the before can be deleted in awake-grafana.nix.