### PR TITLE
[awake-21.05] Backport emptyFile, emptyDir

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -628,6 +628,22 @@ rec {
       installPhase = "cp -R ./ $out";
     };
 
+  /* An immutable file in the store with a length of 0 bytes. */
+  emptyFile = runCommand "empty-file" {
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0ip26j2h11n1kgkz36rl4akv694yz65hr72q4kv4b3lxcbi65b3p";
+    preferLocalBuild = true;
+  } "touch $out";
+
+  /* An immutable empty directory in the store. */
+  emptyDirectory = runCommand "empty-directory" {
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+    preferLocalBuild = true;
+  } "mkdir $out";
+
   /* Checks the command output contains the specified version
    *
    * Although simplistic, this test assures that the main program

--- a/pkgs/build-support/trivial-builders/test/sample.nix
+++ b/pkgs/build-support/trivial-builders/test/sample.nix
@@ -12,4 +12,8 @@ in
   norefs = writeText "hi" "hello";
   helloRef = writeText "hi" "hello ${hello}";
   helloFigletRef = writeText "hi" "hello ${hello} ${figlet}";
+  inherit (pkgs)
+    emptyFile
+    emptyDirectory
+  ;
 }


### PR DESCRIPTION
We would like to use `empty{File,Dir}` in some cases in the 21.05 branch. This backports them from upstream.