### PR TITLE
toGNUCommandLine: Unwrap value if set by mkForce/mkOverride

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -65,9 +65,15 @@ rec {
     # on the toplevel, booleans and lists are handled by `mkBool` and `mkList`,
     # though they can still appear as values of a list.
     # By default, everything is printed verbatim and complex types
-    # are forbidden (lists, attrsets, functions). `null` values are omitted.
+    # are forbidden (lists, attrsets, functions), except that any
+    # attrsets appearing to arise from use of mkForce/mkOverride
+    # are unwrapped. `null` values are omitted.
     mkOption ?
-      k: v: if v == null
+      k: setting:
+        # Unwrap the value if it appears to have been set by mkForce/mkOverride.
+        let v = setting?content then setting.content else setting;
+        in
+          if v == null
             then []
             else [ (mkOptionName k) (lib.generators.mkValueStringDefault {} v) ]
     }:


### PR DESCRIPTION
mkForce/mkOverride place the desired content in the "content" attribute of an attrset, often changing the type of the option.

By default "toGNUCommandLine" will now unwrap such a wrapped value instead of failing, though overrides to "mkOption" option will change this behavior and may add other support for attrsets.

###### Motivation for this change

Command line options are commonly based on NixOS options, and those are often overridden by mkForce/mkOverride.  When this happens the new values are attrsets and cause command line rendering to fail.  This change avoids that problem by default, while preserving generality by modifying only the default behavior.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
