### PR TITLE
toGNUCommandLine: Fix bug in unwrapping of values.

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -76,8 +76,8 @@ rec {
     # By default, everything is printed verbatim and complex types
     # are forbidden (lists, attrsets, functions). `null` values are omitted.
     #
-    # NOTE: If you override this attribute then you
-    # may need to override `preprocessValue` as well.
+    # NOTE: If you override this attribute to support attrsets
+    # then you may need to override `preprocessValue` as well.
     mkOption ?
       k: v: if v == null
             then []

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -43,15 +43,6 @@ rec {
     options: attrs: lib.escapeShellArgs (toGNUCommandLine options attrs);
 
   toGNUCommandLine = {
-    # any preprocessing of an attribute value before we attempt
-    # to convert it to a command line option; by default we try
-    # to unwrap any value that appears to have been wrapped by
-    # mkForce/mkOverride.
-    #
-    # NOTE: If you override `mkOption` to support attrsets
-    # then you may need to override this attribute as well.
-    preprocessValue ? v: v?content then v.content else v,
-
     # how to string-format the option name;
     # by default one character is a short option (`-`),
     # more than one characters a long option (`--`).
@@ -70,14 +61,22 @@ rec {
     # and `mkOption` is applied to the values themselves.
     mkList ? k: v: lib.concatMap (mkOption k) v,
 
+    # any preprocessing of an attribute value of type "override"
+    # before we attempt to convert it to a command line option;
+    # by default we extract its "content" attribute.
+    #
+    # See also the mention of this attribute in the comments for `mkOption`.
+    unwrapOverride ? v: v.content
+
     # how to format any remaining value to a command list;
     # on the toplevel, booleans and lists are handled by `mkBool` and `mkList`,
     # though they can still appear as values of a list.
     # By default, everything is printed verbatim and complex types
     # are forbidden (lists, attrsets, functions). `null` values are omitted.
     #
-    # NOTE: If you override this attribute to support attrsets
-    # then you may need to override `preprocessValue` as well.
+    # NOTE: If you modify this attribute to support attrsets that might
+    # have a "_type" attribute named "override", then consider whether
+    # to also specify a non-default value for `unwrapOverride`.
     mkOption ?
       k: v: if v == null
             then []
@@ -86,10 +85,14 @@ rec {
     options:
       let
         render = k: raw:
-          let v = preprocessValue raw; in
-          if      builtins.isBool v then mkBool k v
-          else if builtins.isList v then mkList k v
-          else mkOption k v;
+          let
+            v = if lib.isType "override" raw
+                then unwrapOverride raw
+                else raw;
+          in
+            if      builtins.isBool v then mkBool k v
+            else if builtins.isList v then mkList k v
+            else mkOption k v;
 
       in
         builtins.concatLists (lib.mapAttrsToList render options);


### PR DESCRIPTION
A wrapped boolean or list value would not
have processed using mkBool or mkList.