### PR TITLE
Apache Kafka backport - awake 21.05

### DIFF
--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -75,7 +75,6 @@ let
   }) { inherit system; });
 
 in with pkgs; {
-  kafka_2_4  = makeKafkaTest "kafka_2_4"  apacheKafka_2_4;
-  kafka_2_5  = makeKafkaTest "kafka_2_5"  apacheKafka_2_5;
-  kafka_2_6  = makeKafkaTest "kafka_2_6"  apacheKafka_2_6;
+  kafka_2_7  = makeKafkaTest "kafka_2_7"  apacheKafka_2_7;
+  kafka_2_8  = makeKafkaTest "kafka_2_8"  apacheKafka_2_8;
 }

--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -75,6 +75,8 @@ let
   }) { inherit system; });
 
 in with pkgs; {
-  kafka_2_7  = makeKafkaTest "kafka_2_7"  apacheKafka_2_7;
   kafka_2_8  = makeKafkaTest "kafka_2_8"  apacheKafka_2_8;
+  kafka_3_0  = makeKafkaTest "kafka_3_0"  apacheKafka_3_0;
+  kafka_3_1  = makeKafkaTest "kafka_3_1"  apacheKafka_3_1;
+  kafka  = makeKafkaTest "kafka"  apacheKafka;
 }

--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -78,5 +78,7 @@ in with pkgs; {
   kafka_2_8  = makeKafkaTest "kafka_2_8"  apacheKafka_2_8;
   kafka_3_0  = makeKafkaTest "kafka_3_0"  apacheKafka_3_0;
   kafka_3_1  = makeKafkaTest "kafka_3_1"  apacheKafka_3_1;
+  kafka_3_2  = makeKafkaTest "kafka_3_2"  apacheKafka_3_2;
+  kafka_3_3  = makeKafkaTest "kafka_3_3"  apacheKafka_3_3;
   kafka  = makeKafkaTest "kafka"  apacheKafka;
 }

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -12,9 +12,9 @@ let
       jre = jre11;
     };
     "2.8" = {
-      kafkaVersion = "2.8.1";
+      kafkaVersion = "2.8.2";
       scalaVersion = "2.13";
-      sha256 = "0fgil47hxdnc374k0p9sxv6b163xknp3pkihv3r99p977czb1228";
+      sha256 = "sha256-inZXZJSs8ivtEqF6E/ApoyUHn8vg38wUG3KhowP8mfQ=";
       jre = jre11;
     };
   };

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -6,25 +6,25 @@ let
     "3.3" = {
       kafkaVersion = "3.3.1";
       scalaVersion = "2.13";
-      sha256 = "440fe73d73ebb78ee0d7accbfd69f53e2281544cf18ea6672c85ef4f6734170b";
+      sha256 = "sha256-GK2KNl+xEd4knTu4vzyWzRrwYOyPs+PR/Ep64Q2QQt4=";
       jre = jdk17_headless;
     };
     "3.2" = {
       kafkaVersion = "3.2.3";
       scalaVersion = "2.13";
-      sha256 = "440fe73d73ebb78ee0d7accbfd69f53e2281544cf18ea6672c85ef4f6734170b";
+      sha256 = "sha256-tvkbwBP83M1zl31J4g6uu4/LEhqJoIA9Eam48fyT24A=";
       jre = jdk17_headless;
     };
     "3.1" = {
       kafkaVersion = "3.1.2";
       scalaVersion = "2.13";
-      sha256 = "e91e50b0aaa499795a51d984a9d00953f9a2781c51314f47ae4df8b2db1a6c9a";
+      sha256 = "sha256-SO1bTQkG3YQSv657QjwBeBCWbDlDqS3E5eUp7ciojnI=";
       jre = jdk17_headless;
     };
     "3.0" = {
       kafkaVersion = "3.0.2";
       scalaVersion = "2.13";
-      sha256 = "1a95abe81dc18eafee65f5bc440ff21ba0c49bd2c6d36bf7878ee8a2e2536097";
+      sha256 = "sha256-G8b6STGlwow+iDqMCeZkF3HTKd94TKccmyfZ7AT/7yE=";
       jre = jdk17_headless;
     };
     "2.8" = {

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -75,6 +75,10 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin\/*
   '';
 
+  passthru = {
+    inherit jre; # Used by the NixOS module to select the supported jre
+  };
+
   meta = with lib; {
     homepage = "https://kafka.apache.org";
     description = "A high-throughput distributed messaging system";
@@ -83,5 +87,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.ragge ];
     platforms = platforms.unix;
   };
-  passthru = { inherit jdk17_headless; };
 }

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -2,32 +2,36 @@
   majorVersion ? "1.0" }:
 
 let
-  jre11 = jdk11_headless;
-  jre   = jdk17_headless;
   versionMap = {
-    "3.2" = {
-      kafkaVersion = "3.2.1";
+    "3.3" = {
+      kafkaVersion = "3.3.1";
       scalaVersion = "2.13";
       sha256 = "440fe73d73ebb78ee0d7accbfd69f53e2281544cf18ea6672c85ef4f6734170b";
-      jre = jre;
+      jre = jdk17_headless;
+    };
+    "3.2" = {
+      kafkaVersion = "3.2.3";
+      scalaVersion = "2.13";
+      sha256 = "440fe73d73ebb78ee0d7accbfd69f53e2281544cf18ea6672c85ef4f6734170b";
+      jre = jdk17_headless;
     };
     "3.1" = {
-      kafkaVersion = "3.1.1";
+      kafkaVersion = "3.1.2";
       scalaVersion = "2.13";
       sha256 = "e91e50b0aaa499795a51d984a9d00953f9a2781c51314f47ae4df8b2db1a6c9a";
-      jre = jre;
+      jre = jdk17_headless;
     };
     "3.0" = {
-      kafkaVersion = "3.0.1";
+      kafkaVersion = "3.0.2";
       scalaVersion = "2.13";
       sha256 = "1a95abe81dc18eafee65f5bc440ff21ba0c49bd2c6d36bf7878ee8a2e2536097";
-      jre = jre;
+      jre = jdk17_headless;
     };
     "2.8" = {
       kafkaVersion = "2.8.2";
       scalaVersion = "2.13";
       sha256 = "sha256-inZXZJSs8ivtEqF6E/ApoyUHn8vg38wUG3KhowP8mfQ=";
-      jre = jre11;
+      jre = jdk11_headless;
     };
 
   };
@@ -79,5 +83,5 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.ragge ];
     platforms = platforms.unix;
   };
-  passthru = { inherit jre; };
+  passthru = { inherit jdk17_headless; };
 }

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
     homepage = "https://kafka.apache.org";
     description = "A high-throughput distributed messaging system";
     license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = [ maintainers.ragge ];
     platforms = platforms.unix;
   };

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -1,15 +1,27 @@
-{ lib, stdenv, fetchurl, jdk8_headless, jdk11_headless, makeWrapper, bash, coreutils, gnugrep, gnused, ps,
+{ lib, stdenv, fetchurl, jdk17_headless, jdk11_headless, makeWrapper, bash, coreutils, gnugrep, gnused, ps,
   majorVersion ? "1.0" }:
 
 let
-  jre8 = jdk8_headless;
   jre11 = jdk11_headless;
+  jre   = jdk17_headless;
   versionMap = {
-    "2.7" = {
-      kafkaVersion = "2.7.1";
+    "3.2" = {
+      kafkaVersion = "3.2.1";
       scalaVersion = "2.13";
-      sha256 = "1qv6blf99211bc80xnd4k42r9v9c5vilyqkplyhsa6hqymg32gfa";
-      jre = jre11;
+      sha256 = "440fe73d73ebb78ee0d7accbfd69f53e2281544cf18ea6672c85ef4f6734170b";
+      jre = jre;
+    };
+    "3.1" = {
+      kafkaVersion = "3.1.1";
+      scalaVersion = "2.13";
+      sha256 = "e91e50b0aaa499795a51d984a9d00953f9a2781c51314f47ae4df8b2db1a6c9a";
+      jre = jre;
+    };
+    "3.0" = {
+      kafkaVersion = "3.0.1";
+      scalaVersion = "2.13";
+      sha256 = "1a95abe81dc18eafee65f5bc440ff21ba0c49bd2c6d36bf7878ee8a2e2536097";
+      jre = jre;
     };
     "2.8" = {
       kafkaVersion = "2.8.2";
@@ -17,6 +29,7 @@ let
       sha256 = "sha256-inZXZJSs8ivtEqF6E/ApoyUHn8vg38wUG3KhowP8mfQ=";
       jre = jre11;
     };
+
   };
 in
 

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -5,22 +5,16 @@ let
   jre8 = jdk8_headless;
   jre11 = jdk11_headless;
   versionMap = {
-    "2.4" = {
-      kafkaVersion = "2.4.1";
-      scalaVersion = "2.12";
-      sha256 = "0ahsprmpjz026mhbr79187wfdrxcg352iipyfqfrx68q878wnxr1";
-      jre = jre8;
-    };
-    "2.5" = {
-      kafkaVersion = "2.5.1";
-      scalaVersion = "2.12";
-      sha256 = "1wn4iszrm2rvsfyyr515zx79k5m86davjkcwcwpxcgc4k3q0z7lv";
-      jre = jre8;
-    };
-    "2.6" = {
-      kafkaVersion = "2.6.1";
+    "2.7" = {
+      kafkaVersion = "2.7.1";
       scalaVersion = "2.13";
-      sha256 = "1a2kd4r6f8z7qf886nnq9f350sblzzdi230j2hll7x156888573y";
+      sha256 = "1qv6blf99211bc80xnd4k42r9v9c5vilyqkplyhsa6hqymg32gfa";
+      jre = jre11;
+    };
+    "2.8" = {
+      kafkaVersion = "2.8.0";
+      scalaVersion = "2.13";
+      sha256 = "1iljfjlp29m4s6gkja9fxkzj8a8p0qc0sfy8x4g1318kbnp818rz";
       jre = jre11;
     };
   };

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://kafka.apache.org";
+    homepage = "https://kafka.apache.org";
     description = "A high-throughput distributed messaging system";
     license = licenses.asl20;
     maintainers = [ maintainers.ragge ];

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -12,9 +12,9 @@ let
       jre = jre11;
     };
     "2.8" = {
-      kafkaVersion = "2.8.0";
+      kafkaVersion = "2.8.1";
       scalaVersion = "2.13";
-      sha256 = "1iljfjlp29m4s6gkja9fxkzj8a8p0qc0sfy8x4g1318kbnp818rz";
+      sha256 = "0fgil47hxdnc374k0p9sxv6b163xknp3pkihv3r99p977czb1228";
       jre = jre11;
     };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12684,10 +12684,9 @@ in
   apacheAnt_1_9 = callPackage ../development/tools/build-managers/apache-ant/1.9.nix { };
   ant = apacheAnt;
 
-  apacheKafka = apacheKafka_2_6;
-  apacheKafka_2_4 = callPackage ../servers/apache-kafka { majorVersion = "2.4"; };
-  apacheKafka_2_5 = callPackage ../servers/apache-kafka { majorVersion = "2.5"; };
-  apacheKafka_2_6 = callPackage ../servers/apache-kafka { majorVersion = "2.6"; };
+  apacheKafka = apacheKafka_2_8;
+  apacheKafka_2_7 = callPackage ../servers/apache-kafka { majorVersion = "2.7"; };
+  apacheKafka_2_8 = callPackage ../servers/apache-kafka { majorVersion = "2.8"; };
 
   kt = callPackage ../tools/misc/kt {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12684,9 +12684,11 @@ in
   apacheAnt_1_9 = callPackage ../development/tools/build-managers/apache-ant/1.9.nix { };
   ant = apacheAnt;
 
-  apacheKafka = apacheKafka_2_8;
-  apacheKafka_2_7 = callPackage ../servers/apache-kafka { majorVersion = "2.7"; };
+  apacheKafka = apacheKafka_3_2;
   apacheKafka_2_8 = callPackage ../servers/apache-kafka { majorVersion = "2.8"; };
+  apacheKafka_3_0 = callPackage ../servers/apache-kafka { majorVersion = "3.0"; };
+  apacheKafka_3_1 = callPackage ../servers/apache-kafka { majorVersion = "3.1"; };
+  apacheKafka_3_2 = callPackage ../servers/apache-kafka { majorVersion = "3.2"; };
 
   kt = callPackage ../tools/misc/kt {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12684,11 +12684,12 @@ in
   apacheAnt_1_9 = callPackage ../development/tools/build-managers/apache-ant/1.9.nix { };
   ant = apacheAnt;
 
-  apacheKafka = apacheKafka_3_2;
+  apacheKafka = apacheKafka_3_3;
   apacheKafka_2_8 = callPackage ../servers/apache-kafka { majorVersion = "2.8"; };
   apacheKafka_3_0 = callPackage ../servers/apache-kafka { majorVersion = "3.0"; };
   apacheKafka_3_1 = callPackage ../servers/apache-kafka { majorVersion = "3.1"; };
   apacheKafka_3_2 = callPackage ../servers/apache-kafka { majorVersion = "3.2"; };
+  apacheKafka_3_3 = callPackage ../servers/apache-kafka { majorVersion = "3.3"; };
 
   kt = callPackage ../tools/misc/kt {};
 


### PR DESCRIPTION
Apache kafka update to the latest version (backport from nixpkgs 22.11). I don't think it should break something, but I'll test it on the 'end-to-end' to be sure and let you know @jsoo1. 