### PR TITLE
[awake-21.05] stdenv/generic: introduce shellDryRun

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -171,6 +171,11 @@ let
       inherit overrides;
 
       inherit cc hasCC;
+
+      # Convenience for doing some very basic shell syntax checking by parsing a script
+      # without running any commands. Because this will also skip `shopt -s extglob`
+      # commands and extglob affects the Bash parser, we enable extglob always.
+      shellDryRun = "${stdenv.shell} -n -O extglob";
     }
 
     # Propagate any extra attributes.  For instance, we use this to


### PR DESCRIPTION
To fix `writeShellApplication` which uses `shellDryRun` on the revision we prefer.