### PR TITLE
[21.05] nixos/systemd: check that services actually run something

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -11,6 +11,10 @@ let
 
   systemd = cfg.package;
 
+  enabledUpstreamSystemUnits = filter (n: ! elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
+
+  knownEnabledServices = [ "nix-daemon" ];
+
   upstreamSystemUnits =
     [ # Targets.
       "basic.target"
@@ -907,6 +911,12 @@ in
             type = service.serviceConfig.Type or "";
             restart = service.serviceConfig.Restart or "no";
             hasDeprecated = builtins.hasAttr "StartLimitInterval" service.serviceConfig;
+            hasStartCmd = svc:
+              svc.script != ""
+              || svc.serviceConfig?ExecStart
+              || svc.serviceConfig?ExecStop;
+            templateUnit = builtins.match "^(.*@).*" name;
+            template = builtins.elemAt templateUnit 0;
           in
             concatLists [
               (optional (type == "oneshot" && (restart == "always" || restart == "on-success"))
@@ -915,6 +925,14 @@ in
               (optional hasDeprecated
                 "Service '${name}.service' uses the attribute 'StartLimitInterval' in the Service section, which is deprecated. See https://github.com/NixOS/nixpkgs/issues/45786."
               )
+              (optional
+                (service.enable
+                  && !hasStartCmd service
+                  && !(lib.elem name knownEnabledServices)
+                  && !(!isNull templateUnit && cfg.services?${template} && hasStartCmd cfg.services.${template})
+                  && !(lib.elem "${name}.service" enabledUpstreamSystemUnits)
+                  && builtins.all (p: isNull ((builtins.match "^${name}.*") p.name)) cfg.packages)
+                "Service `${name}' is enabled and missing a `script' or one of ExecStart= or ExecStop=.")
             ]
         )
         cfg.services
@@ -957,7 +975,6 @@ in
         ${concatStrings (mapAttrsToList (exec: target: "ln -s ${target} $out/${exec};\n") links)}
       '';
 
-      enabledUpstreamSystemUnits = filter (n: ! elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
       enabledUnits = filterAttrs (n: v: ! elem n cfg.suppressedSystemUnits) cfg.units;
     in ({
       "systemd/system".source = generateUnits "system" enabledUnits enabledUpstreamSystemUnits upstreamSystemWants;


### PR DESCRIPTION
To avoid the situation where a service unit file may have a [Unit] but no valid [Service].