### PR TITLE
[21.11] nixos/nghttpx: parameterize user, require timeouts

### DIFF
--- a/nixos/modules/services/networking/nghttpx/default.nix
+++ b/nixos/modules/services/networking/nghttpx/default.nix
@@ -109,6 +109,7 @@ in
 
     systemd.services = {
       nghttpx = {
+        path = [ pkgs.python3 pkgs.openssl.bin ];
         wantedBy = [ "multi-user.target" ];
         after    = [ "network.target" ];
         script   = ''

--- a/nixos/modules/services/networking/nghttpx/nghttpx-options.nix
+++ b/nixos/modules/services/networking/nghttpx/nghttpx-options.nix
@@ -62,6 +62,24 @@
       '';
     };
 
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "nghttpx";
+      description = ''
+        User to drop privileges to.
+
+        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--user
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "nghttpx";
+      description = ''
+        Group to drop privileges to.
+      '';
+    };
+
     single-process = lib.mkOption {
       type        = lib.types.bool;
       default     = false;
@@ -136,6 +154,38 @@
         is given, nghttpx does not set the limit.
 
         Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--rlimit-nofile
+      '';
+    };
+
+    backend-read-timeout = lib.mkOption {
+      type = lib.types.str;
+      default = "1m";
+      description = ''
+        Specify read timeout for backend connection.
+      '';
+    };
+
+    backend-write-timeout = lib.mkOption {
+      type = lib.types.str;
+      default = "30s";
+      description = ''
+        Specify write timeout for backend connection.
+      '';
+    };
+
+    frontend-read-timeout = lib.mkOption {
+      type = lib.types.str;
+      default = "1m";
+      description = ''
+        Specify read timeout for HTTP/1.1 frontend connection
+      '';
+    };
+
+    frontend-write-timeout = lib.mkOption {
+      type = lib.types.str;
+      default = "30s";
+      description = ''
+        Specify write timeout for all frontend connections
       '';
     };
   };


### PR DESCRIPTION
To configure necessary timeouts and parameterize user/group.  nghttpx was upstreamed and this is all that remains of the diff.