### PR TITLE
[awake-21.05] writers.awkFormatNginx: skip host_spoofing

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -245,7 +245,7 @@ rec {
   } /* sh */ ''
     # nginx-config-formatter has an error - https://github.com/1connect/nginx-config-formatter/issues/16
     awk -f ${awkFormatNginx} "$textPath" | sed '/^\s*$/d' > $out
-    gixy $out
+    gixy --skips host_spoofing $out
   '';
 
   # writePerl takes a name an attributeset with libraries and some perl sourcecode and


### PR DESCRIPTION
It can fail on valid inputs.