### PR TITLE
vim-utils: add `vi` and `gvi` symlinks to vim wrapper scripts

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -371,14 +371,33 @@ rec {
   }:
     let
       rcOption = o: file: lib.optionalString (file != null) "-${o} ${file}";
-      vimWrapperScript = writeScriptBin vimExecutableName ''
+      vimWrapperScript = (writeScriptBin vimExecutableName ''
         #!${runtimeShell}
         exec ${vimExecutable} ${rcOption "u" vimrcFile} ${rcOption "U" gvimrcFile} "$@"
-      '';
-      gvimWrapperScript = writeScriptBin gvimExecutableName ''
+      '').overrideAttrs (oldAttrs: {
+        buildCommand = ''
+          ${oldAttrs.buildCommand}
+          eval "$postBuild"
+        '';
+
+        postBuild = ''
+          ln -s $out/bin/${vimExecutableName} $out/bin/vi
+        '';
+      });
+
+      gvimWrapperScript = (writeScriptBin gvimExecutableName ''
         #!${stdenv.shell}
         exec ${gvimExecutable} ${rcOption "u" vimrcFile} ${rcOption "U" gvimrcFile} "$@"
-      '';
+      '').overrideAttrs (oldAttrs: {
+        buildCommand = ''
+          ${oldAttrs.buildCommand}
+          eval "$postBuild"
+        '';
+
+        postBuild = ''
+          ln -s $out/bin/${gvimExecutableName} $out/bin/gvi
+        '';
+      });;
     in
       buildEnv {
         inherit name;

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -368,7 +368,7 @@ rec {
     gvimrcFile ? null,
     vimExecutableName,
     gvimExecutableName,
-  }:
+  }: assert (lib.assertMsg (lib.versionAtLeast "21.11" lib.trivial.release) "Time to remove the vimWrapperScript overrides that symlink `vi -> vim`!");
     let
       rcOption = o: file: lib.optionalString (file != null) "-${o} ${file}";
       vimWrapperScript = (writeScriptBin vimExecutableName ''


### PR DESCRIPTION
... so that their `bin`'s are populated with the convenience symlinks that people expect.

This change also adds an assertion reminder to remove the e7bfb04 changes once we upgrade to a `nixpkgs` > 21.11.