### PR TITLE
[21.11] vim-utils: add `vi` and `gvi` symlinks to vim wrapper scripts

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -415,7 +415,7 @@ rec {
     gvimrcFile ? null,
     vimExecutableName,
     gvimExecutableName,
-  }:
+  }: assert (lib.assertMsg (lib.versionAtLeast "21.11" lib.trivial.release) "Time to remove the vimWrapperScript overrides that symlink `vi -> vim`!");
     let
       rcOption = o: file: lib.optionalString (file != null) "-${o} ${file}";
       vimWrapperScript = writeScriptBin vimExecutableName ''


### PR DESCRIPTION
... so that their `bin`'s are populated with the convenience symlinks that people expect.

This change also adds an assertion reminder to remove the e7bfb04 changes once we upgrade to a `nixpkgs` > 21.11.

Forward port of #90.