### PR TITLE
Tomask/bump black to 22.3.0

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -23,13 +23,13 @@
 
 buildPythonPackage rec {
   pname = "black";
-  version = "22.1.0";
+  version = "22.3.0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-p8AZLTVjX2/BF0vldct5FekuXdYp7nn9rw3PpBqAr7U=";
+    hash = "sha256-NQILiIbAIs7ZKCtRtah1ttGrDDh7MaBluE23wzCFynk=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -10,7 +10,6 @@
 , pathspec
 , parameterized
 , platformdirs
-, regex
 , tomli
 , typed-ast
 , typing-extensions
@@ -20,13 +19,13 @@
 
 buildPythonPackage rec {
   pname = "black";
-  version = "21.10b0";
+  version = "21.12b0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-qZUiKQkuMl/l89rlbYH2ObI/cTHrhAeBlH5LKIYDDzM=";
+    hash = "sha256-d7gPaTpWni5SeVhFljTxjfmwuiYluk4MLV2lvkLm8rM=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];
@@ -71,7 +70,6 @@ buildPythonPackage rec {
     mypy-extensions
     pathspec
     platformdirs
-    regex
     tomli
     typed-ast # required for tests and python2 extra
     uvloop

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -60,11 +60,9 @@ buildPythonPackage rec {
     # Fail on Hydra, see https://github.com/NixOS/nixpkgs/pull/130785
     "test_bpo_2142_workaround"
     "test_skip_magic_trailing_comma"
-  ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
-    # they exceed max open files on hydra builders
-    "test_blackd_supported_version"
-    "test_cors_headers_present"
   ];
+  # multiple tests exceed max open files on hydra builders
+  doCheck = !(stdenv.isLinux && stdenv.isAarch64);
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -61,8 +61,9 @@ buildPythonPackage rec {
     "test_bpo_2142_workaround"
     "test_skip_magic_trailing_comma"
   ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
-    # exceeds max open files on hydra builders
+    # they exceed max open files on hydra builders
     "test_blackd_supported_version"
+    "test_cors_headers_present"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -1,8 +1,12 @@
-{ stdenv, lib
-, buildPythonPackage, fetchPypi, pythonOlder, setuptools-scm, pytestCheckHook
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+, pytestCheckHook
 , aiohttp
 , aiohttp-cors
-, attrs
 , click
 , colorama
 , dataclasses
@@ -19,13 +23,13 @@
 
 buildPythonPackage rec {
   pname = "black";
-  version = "21.12b0";
+  version = "22.1.0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-d7gPaTpWni5SeVhFljTxjfmwuiYluk4MLV2lvkLm8rM=";
+    hash = "sha256-p8AZLTVjX2/BF0vldct5FekuXdYp7nn9rw3PpBqAr7U=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];
@@ -64,17 +68,15 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     aiohttp
     aiohttp-cors
-    attrs
     click
     colorama
     mypy-extensions
     pathspec
     platformdirs
     tomli
-    typed-ast # required for tests and python2 extra
     uvloop
-  ] ++ lib.optional (pythonOlder "3.7") dataclasses
-    ++ lib.optional (pythonOlder "3.8") typing-extensions;
+  ] ++ lib.optional (pythonOlder "3.8") typed-ast
+  ++ lib.optional (pythonOlder "3.10") typing-extensions;
 
   meta = with lib; {
     description = "The uncompromising Python code formatter";


### PR DESCRIPTION
Bumping `black` to 22.3.0, which is the version we use to check our Python sources formatting.