### PR TITLE
[21.11] Backport newer versions of `abseil-cpp`

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/202103.nix
+++ b/pkgs/development/libraries/abseil-cpp/202103.nix
@@ -25,6 +25,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/abseil/abseil-cpp/commit/5bfa70c75e621c5d5ec095c8c4c0c050dcb2957e.patch";
       sha256 = "0nhjxqfxpi2pkfinnqvd5m4npf9l1kg39mjx9l3087ajhadaywl5";
     })
+  ] ++ lib.optionals stdenv.hostPlatform.isLoongArch64 [
+    # https://github.com/abseil/abseil-cpp/pull/1110
+    (fetchpatch {
+      url = "https://github.com/abseil/abseil-cpp/commit/808bc202fc13e85a7948db0d7fb58f0f051200b1.patch";
+      sha256 = "sha256-ayY/aV/xWOdEyFSDqV7B5WDGvZ0ASr/aeBeYwP5RZVc=";
+    })
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/abseil-cpp/202103.nix
+++ b/pkgs/development/libraries/abseil-cpp/202103.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "abseil";
     repo = "abseil-cpp";
     rev = version;
-    sha256 = "0g9rbhk3mwjdfxk7cscd04vm8fphd5flz9yykpgvyy1nwa34zk3x";
+    sha256 = "sha256-fcxPhuI2eL/fnd6nT11p8DpUNwGNaXZmd03yOiZcOT0=";
   };
 
   patches = [

--- a/pkgs/development/libraries/abseil-cpp/202111.nix
+++ b/pkgs/development/libraries/abseil-cpp/202111.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, static ? stdenv.hostPlatform.isStatic
+, cxxStandard ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "abseil-cpp";
+  version = "20211102.0";
+
+  src = fetchFromGitHub {
+    owner = "abseil";
+    repo = "abseil-cpp";
+    rev = version;
+    sha256 = "sha256-sSXT6D4JSrk3dA7kVaxfKkzOMBpqXQb0WbMYWG+nGwk=";
+  };
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
+  ] ++ lib.optionals (cxxStandard != null) [
+    "-DCMAKE_CXX_STANDARD=${cxxStandard}"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "An open-source collection of C++ code designed to augment the C++ standard library";
+    homepage = "https://abseil.io/";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [ maintainers.andersk ];
+  };
+}

--- a/pkgs/development/libraries/abseil-cpp/202206.nix
+++ b/pkgs/development/libraries/abseil-cpp/202206.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, static ? stdenv.hostPlatform.isStatic
+, cxxStandard ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "abseil-cpp";
+  version = "20220623.1";
+
+  src = fetchFromGitHub {
+    owner = "abseil";
+    repo = "abseil-cpp";
+    rev = "refs/tags/${version}";
+    hash = "sha256-Od1FZOOWEXVQsnZBwGjDIExi6LdYtomyL0STR44SsG8=";
+  };
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
+  ] ++ lib.optionals (cxxStandard != null) [
+    "-DCMAKE_CXX_STANDARD=${cxxStandard}"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "An open-source collection of C++ code designed to augment the C++ standard library";
+    homepage = "https://abseil.io/";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [ maintainers.andersk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15647,7 +15647,9 @@ with pkgs;
 
   aalib = callPackage ../development/libraries/aalib { };
 
-  abseil-cpp = callPackage ../development/libraries/abseil-cpp { };
+  abseil-cpp_202111 = callPackage ../development/libraries/abseil-cpp/202111.nix { };
+  abseil-cpp_202103 = callPackage ../development/libraries/abseil-cpp/202103.nix { };
+  abseil-cpp = abseil-cpp_202103;
 
   accountsservice = callPackage ../development/libraries/accountsservice { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15649,6 +15649,7 @@ with pkgs;
 
   abseil-cpp_202111 = callPackage ../development/libraries/abseil-cpp/202111.nix { };
   abseil-cpp_202103 = callPackage ../development/libraries/abseil-cpp/202103.nix { };
+  abseil-cpp_202206 = callPackage ../development/libraries/abseil-cpp/202206.nix { };
   abseil-cpp = abseil-cpp_202103;
 
   accountsservice = callPackage ../development/libraries/accountsservice { };


### PR DESCRIPTION
```
git cherry-pick \
    a0da54e4d11c289b0c8b5fae54bd77be0cb5af10 \
    7399b9f0cf95f3d1848e3f18268243924848e966 \
    23bd354873a082f7d722afd74f84af862cc9dddf
```

This only adds new versions and keeps default where it was - should apply cleanly