### PR TITLE
[21.11] python3Packages.frozendict: 2.0.7 -> 2.3.4

### DIFF
--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,20 +8,15 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.1.1";
+  version = "2.2.0";
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "655b879217dd445a2023e16154cc231febef802b5c812d5c2e822280ad69e1dc";
+    sha256 = "sha256-jj1HNfmhPRB3Vn5WhHFmPzJE+FrImyP4yzHPIx2+Rbk=";
   };
-
-  postPatch = ''
-    # fixes build on non-x86_64 architectures
-    rm frozendict/src/3_9/cpython_src/Include/pyconfig.h
-  '';
 
   pythonImportsCheck = [
     "frozendict"
@@ -32,24 +27,12 @@ buildPythonPackage rec {
   ];
 
   preCheck = ''
-    rm -r frozendict
-    export PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
+    pushd test
   '';
 
-  disabledTests = [
-    # TypeError: unsupported operand type(s) for |=: 'frozendict.frozendict' and 'dict'
-    "test_union"
-    # non-standard assertions
-    "test_repr"
-    "test_format"
-    "test_str"
-  ];
-
-  disabledTestPaths = [
-    # unpackaged test dependency: coold
-    "test/test_coold.py"
-    "test/test_coold_subclass.py"
-  ];
+  postCheck = ''
+    popd
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/slezica/python-frozendict";

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.3.0";
+  version = "2.3.1";
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1dd0bqhai4k3fj9ydcwmc9hvbmrsklk349ys21w8x4n5xynk2hns";
+    sha256 = "sha256-vJHGkjPrkWu268QJiLbYSXNXcCQO/JxgvkW0q5GcG94=";
   };
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.1.0";
+  version = "2.1.1";
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0189168749ddea8601afd648146c502533f93ae33840eb76cd71f694742623cd";
+    sha256 = "655b879217dd445a2023e16154cc231febef802b5c812d5c2e822280ad69e1dc";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.3.3";
+  version = "2.3.4";
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-OYU5xSrzxkfRAxhbuqEpFnnwUHrQNf47qyqLA2bVLPE=";
+    sha256 = "15b4b18346259392b0d27598f240e9390fafbff882137a9c48a1e0104fb17f78";
   };
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.3.1";
+  version = "2.3.2";
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-vJHGkjPrkWu268QJiLbYSXNXcCQO/JxgvkW0q5GcG94=";
+    sha256 = "sha256-f6xFQvChP75wTbSUL0G6Or/+xa+LEAAllz5Z3/agnQ0=";
   };
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , isPy3k
 , pytestCheckHook
-, python
 }:
 
 buildPythonPackage rec {
@@ -35,8 +34,8 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/slezica/python-frozendict";
-    description = "An immutable dictionary";
-    license = licenses.mit;
+    homepage = "https://github.com/Marco-Sulla/python-frozendict";
+    description = "A simple immutable dictionary";
+    license = licenses.lgpl3Only;
   };
 }

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.3.2";
+  version = "2.3.3";
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-f6xFQvChP75wTbSUL0G6Or/+xa+LEAAllz5Z3/agnQ0=";
+    sha256 = "sha256-OYU5xSrzxkfRAxhbuqEpFnnwUHrQNf47qyqLA2bVLPE=";
   };
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.1.0";  # 2.0.6 breaks canonicaljson
+  version = "2.1.0";
   format = "setuptools";
 
   disabled = !isPy3k;

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.2.0";
+  version = "2.3.0";
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-jj1HNfmhPRB3Vn5WhHFmPzJE+FrImyP4yzHPIx2+Rbk=";
+    sha256 = "1dd0bqhai4k3fj9ydcwmc9hvbmrsklk349ys21w8x4n5xynk2hns";
   };
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "2.0.7";  # 2.0.6 breaks canonicaljson
+  version = "2.1.0";  # 2.0.6 breaks canonicaljson
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a68f609d1af67da80b45519fdcfca2d60249c0a8c96e68279c1b6ddd92128204";
+    sha256 = "0189168749ddea8601afd648146c502533f93ae33840eb76cd71f694742623cd";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -39,6 +39,10 @@ buildPythonPackage rec {
   disabledTests = [
     # TypeError: unsupported operand type(s) for |=: 'frozendict.frozendict' and 'dict'
     "test_union"
+    # non-standard assertions
+    "test_repr"
+    "test_format"
+    "test_str"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Another batch of python backports

```
git cherry-pick \
    3dffd60b206b07b087ce1d589d2fccfe107cd342 \
    7f9f1ecd900c163362b69685ec6d799edcdbb334 \
    f8628e91abeefa1ab908ed1e105df6b4cd9372b9 \
    b7ca8b4a64783d6465552e53c73affe163f64649 \
    113346fed8c97db4b4dda7352eb6d1b960fbfeac \
    810249eb77f873de38b8ea2ab0c750dcae8b2e5c \
    80fd713fe6d7bb9f0247e1f967046ce6889c18dd \
    4b9c71f4a5c23360410f27c7573eb01a6e48ff11 \
    bff5824e32b934aa3766e23ce389b1490976cde9 \
    44d41315bf315223342effb46aa9c16e97442673 \
    7c8c39c8faebdc006c2ef1e99e4527ab4825d86d
```

https://github.com/NixOS/nixpkgs/commit/687b1233c24e3f3661a6ecaa74b9bbf08454f0df was already present