### PR TITLE
Bump moto version and its dependencies

### DIFF
--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "boto3";
-  version = "1.20.13"; # N.B: if you change this, change botocore and awscli to a matching version
+  version = "1.20.21"; # N.B: if you change this, change botocore and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bbf53a077d6a0575ddec8026f0475ca6ee6f41b227914bf315bf3e049a3d653a";
+    sha256 = "2fb05cbe81b9ce11d9394fc6c4ffa5fd1cceb114dc1d2887dc61081707e44522";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "boto3";
-  version = "1.20.21"; # N.B: if you change this, change botocore and awscli to a matching version
+  version = "1.20.35"; # N.B: if you change this, change botocore and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2fb05cbe81b9ce11d9394fc6c4ffa5fd1cceb114dc1d2887dc61081707e44522";
+    sha256 = "42dd9fcb9e033ab19c9dfaeaba745ef9d2db6efe4e9f1e1f547b3e3e0b1f4a82";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "boto3";
-  version = "1.18.54"; # N.B: if you change this, change botocore and awscli to a matching version
+  version = "1.20.13"; # N.B: if you change this, change botocore and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-LYHcSEAgBZ/HOBZZhDBBB9TbHGd0tjENCMiSoXUfaYA=";
+    sha256 = "bbf53a077d6a0575ddec8026f0475ca6ee6f41b227914bf315bf3e049a3d653a";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "boto3";
-  version = "1.21.12"; # N.B: if you change this, change botocore and awscli to a matching version
+  version = "1.21.30"; # N.B: if you change this, change botocore and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-yS7CCmcHIbWhvAE7MFqE2yt/nHFmU7MFbOfi+9KhgO8=";
+    sha256 = "sha256-8K+PTvX+Y1PHlM08zmJ9Rpphi1is58p1pjz9cZ32Fc4=";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "boto3";
-  version = "1.21.11"; # N.B: if you change this, change botocore and awscli to a matching version
+  version = "1.21.12"; # N.B: if you change this, change botocore and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-8s7PXRdvOYo5v94ACN+DwD8hQrK+XqvjK/EElh32iBA=";
+    sha256 = "sha256-yS7CCmcHIbWhvAE7MFqE2yt/nHFmU7MFbOfi+9KhgO8=";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "boto3";
-  version = "1.20.35"; # N.B: if you change this, change botocore and awscli to a matching version
+  version = "1.21.11"; # N.B: if you change this, change botocore and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "42dd9fcb9e033ab19c9dfaeaba745ef9d2db6efe4e9f1e1f547b3e3e0b1f4a82";
+    sha256 = "sha256-8s7PXRdvOYo5v94ACN+DwD8hQrK+XqvjK/EElh32iBA=";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.23.14"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.23.21"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-6NUsvy5zxiaM8sIH9H48+z7eCYP5PotZZ0tUYo5+8fE=";
+    sha256 = "d7f8e82cba38aa1e66015cab0a5ca3204503e90afc4695e97228e28329a14c04";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.23.21"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.23.35"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d7f8e82cba38aa1e66015cab0a5ca3204503e90afc4695e97228e28329a14c04";
+    sha256 = "5be6ba6c5ea71c256da8a5023bf9c278847c4b90fdb40f2c4c3bdb21ca11ff28";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.21.54"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.23.13"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-RhJ7OjhdDsc9GZS4lYsjt54GE+EsSGNxoQDfmStyobk=";
+    sha256 = "35792b2196049ef900f538cae51fb8359c940156eef187962aa9e3bd2c0b8e8c";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.24.12"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.24.30"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-AXSZmgSwouQkVxBgk6zps2+pR3KkQtm89gdQJj0dBz4=";
+    sha256 = "sha256-r0vcUe7svp/c2tvtmtWMXJE4DvMPNWACK7wu4dePCtY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.23.13"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.23.14"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "35792b2196049ef900f538cae51fb8359c940156eef187962aa9e3bd2c0b8e8c";
+    sha256 = "sha256-6NUsvy5zxiaM8sIH9H48+z7eCYP5PotZZ0tUYo5+8fE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.24.30"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.24.33"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-r0vcUe7svp/c2tvtmtWMXJE4DvMPNWACK7wu4dePCtY=";
+    sha256 = "sha256-6l/RgAggMKbDP6Gb8BHXKXDz7SPP/xtBQTBp4yV2gQM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.24.11"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.24.12"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-Kvk95wTzEih4oyM+fPXeCwL2xMn6mTyoU7WD9Ze7HDg=";
+    sha256 = "sha256-AXSZmgSwouQkVxBgk6zps2+pR3KkQtm89gdQJj0dBz4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.23.35"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.24.11"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5be6ba6c5ea71c256da8a5023bf9c278847c4b90fdb40f2c4c3bdb21ca11ff28";
+    sha256 = "sha256-Kvk95wTzEih4oyM+fPXeCwL2xMn6mTyoU7WD9Ze7HDg=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -264,6 +264,8 @@ buildPythonPackage rec {
     "test_state_machine_creation_fails_with_invalid_names"
     # needs graphql
     "test_get_schema_creation_status"
+    # only appears in aarch64 currently, but best to be safe
+    "test_state_machine_list_executions_with_filter"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -1,269 +1,115 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, fetchpatch
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+
+# runtime
 , aws-xray-sdk
-, backports_tempfile
 , boto3
 , botocore
 , cfn-lint
+, cryptography
 , docker
 , flask
 , flask-cors
-, freezegun
+, graphql-core
+, idna
 , jinja2
 , jsondiff
-, mock
-, pyaml
+, python-dateutil
 , python-jose
 , pytz
+, pyyaml
 , requests
 , responses
-, six
 , sshpubkeys
-, sure
 , werkzeug
 , xmltodict
-, parameterized
-, idna
-, nose
+
+# tests
+, freezegun
 , pytestCheckHook
 , pytest-xdist
+, sure
 }:
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "3.0.2";
+  version = "3.0.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-vZ1oofOYUkFETDFKwSmifvvn+bCi/6NQAxu950NYk5k=";
+    sha256 = "sha256-hfLs4K0DBaoTo5E5zmSKs6/hwEyzKsHbjV5ekRfU0Q4=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "ecdsa<0.15" "ecdsa" \
-      --replace "idna<3,>=2.5" "idna" \
-      --replace "MarkupSafe<2.0" "MarkupSafe" \
-  '';
 
   propagatedBuildInputs = [
     aws-xray-sdk
     boto3
     botocore
     cfn-lint
+    cryptography
     docker
-    flask # required for server
+    flask
+    flask-cors
+    graphql-core
+    idna
     jinja2
     jsondiff
-    mock
-    pyaml
+    python-dateutil
     python-jose
     pytz
-    six
+    pyyaml
     requests
     responses
     sshpubkeys
     werkzeug
     xmltodict
-    idna
-  ] ++ lib.optionals isPy27 [ backports_tempfile ];
+  ];
 
   checkInputs = [
-    boto3
-    flask-cors
     freezegun
-    parameterized
-    pytestCheckHook
     pytest-xdist
+    pytestCheckHook
     sure
   ];
 
-  # Multiple test files still import boto, rather than boto3 like
-  # boto is long-deprecated and broken on python3.9
-  # https://github.com/spulec/moto/blob/63ce647123755e4c4693a89f52c254596004c098/tests/test_autoscaling/test_autoscaling.py#L2
-  # NOTE: This should change to use disabledTestFiles / disabledTestPaths once that
-  # feature stabalizes: see #113153 (mostly the discussion therein), #113167, #110700
   pytestFlagsArray = [
-    "-n $NIX_BUILD_CORES"
-    "--ignore=tests/test_awslambda/test_policy.py"
-    "--ignore=tests/test_autoscaling/test_autoscaling.py"
-    "--ignore=tests/test_autoscaling/test_cloudformation.py"
-    "--ignore=tests/test_autoscaling/test_elbv2.py"
-    "--ignore=tests/test_autoscaling/test_launch_configurations.py"
-    "--ignore=tests/test_autoscaling/test_policies.py"
-    "--ignore=tests/test_autoscaling/test_server.py"
-    "--ignore=tests/test_awslambda/test_lambda.py"
-    "--ignore=tests/test_awslambda/test_lambda_cloudformation.py"
-    "--ignore=tests/test_batch/test_cloudformation.py"
-    "--ignore=tests/test_batch/test_server.py"
-    "--ignore=tests/test_cloudformation/test_cloudformation_depends_on.py"
-    "--ignore=tests/test_cloudformation/test_cloudformation_stack_crud.py"
-    "--ignore=tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py"
-    "--ignore=tests/test_cloudformation/test_cloudformation_stack_integration.py"
-    "--ignore=tests/test_cloudformation/test_stack_parsing.py"
-    "--ignore=tests/test_cloudformation/test_validate.py"
-    "--ignore=tests/test_cloudwatch/test_cloudwatch.py"
-    "--ignore=tests/test_cognitoidentity/test_server.py"
-    "--ignore=tests/test_config/test_config.py"
-    "--ignore=tests/test_core/test_auth.py"
-    "--ignore=tests/test_core/test_decorator_calls.py"
-    "--ignore=tests/test_core/test_nested.py"
-    "--ignore=tests/test_core/test_server.py"
-    "--ignore=tests/test_datapipeline/test_datapipeline.py"
-    "--ignore=tests/test_datapipeline/test_server.py"
-    "--ignore=tests/test_datasync/test_datasync.py"
-    "--ignore=tests/test_dynamodb/test_dynamodb.py"
-    "--ignore=tests/test_dynamodb/test_dynamodb_table_with_range_key.py"
-    "--ignore=tests/test_dynamodb/test_dynamodb_table_without_range_key.py"
-    "--ignore=tests/test_dynamodb/test_server.py"
-    "--ignore=tests/test_dynamodb2/test_dynamodb.py"
-    "--ignore=tests/test_dynamodb2/test_dynamodb_table_with_range_key.py"
-    "--ignore=tests/test_dynamodb2/test_dynamodb_table_without_range_key.py"
-    "--ignore=tests/test_dynamodb2/test_server.py"
-    "--ignore=tests/test_ec2/test_amazon_dev_pay.py"
-    "--ignore=tests/test_ec2/test_amis.py"
-    "--ignore=tests/test_ec2/test_availability_zones_and_regions.py"
-    "--ignore=tests/test_ec2/test_customer_gateways.py"
-    "--ignore=tests/test_ec2/test_dhcp_options.py"
-    "--ignore=tests/test_ec2/test_elastic_block_store.py"
-    "--ignore=tests/test_ec2/test_elastic_ip_addresses.py"
-    "--ignore=tests/test_ec2/test_elastic_network_interfaces.py"
-    "--ignore=tests/test_ec2/test_general.py"
-    "--ignore=tests/test_ec2/test_instances.py"
-    "--ignore=tests/test_ec2/test_internet_gateways.py"
-    "--ignore=tests/test_ec2/test_ip_addresses.py"
-    "--ignore=tests/test_ec2/test_key_pairs.py"
-    "--ignore=tests/test_ec2/test_monitoring.py"
-    "--ignore=tests/test_ec2/test_network_acls.py"
-    "--ignore=tests/test_ec2/test_placement_groups.py"
-    "--ignore=tests/test_ec2/test_regions.py"
-    "--ignore=tests/test_ec2/test_reserved_instances.py"
-    "--ignore=tests/test_ec2/test_route_tables.py"
-    "--ignore=tests/test_ec2/test_security_groups.py"
-    "--ignore=tests/test_ec2/test_spot_instances.py"
-    "--ignore=tests/test_ec2/test_subnets.py"
-    "--ignore=tests/test_ec2/test_tags.py"
-    "--ignore=tests/test_ec2/test_virtual_private_gateways.py"
-    "--ignore=tests/test_ec2/test_vm_export.py"
-    "--ignore=tests/test_ec2/test_vm_import.py"
-    "--ignore=tests/test_ec2/test_vpc_peering.py"
-    "--ignore=tests/test_ec2/test_vpcs.py"
-    "--ignore=tests/test_ec2/test_vpn_connections.py"
-    "--ignore=tests/test_ec2/test_vpn_connections.py"
-    "--ignore=tests/test_ec2/test_windows.py"
-    "--ignore=tests/test_ecs/test_ecs_boto3.py"
-    "--ignore=tests/test_elb/test_elb.py"
-    "--ignore=tests/test_elb/test_server.py"
-    "--ignore=tests/test_elbv2/test_elbv2.py"
-    "--ignore=tests/test_elbv2/test_server.py"
-    "--ignore=tests/test_emr/test_emr.py"
-    "--ignore=tests/test_emr/test_server.py"
-    "--ignore=tests/test_glacier/test_glacier_archives.py"
-    "--ignore=tests/test_glacier/test_glacier_jobs.py"
-    "--ignore=tests/test_glacier/test_glacier_vaults.py"
-    "--ignore=tests/test_iam/test_iam.py"
-    "--ignore=tests/test_iam/test_iam_cloudformation.py"
-    "--ignore=tests/test_iam/test_iam_groups.py"
-    "--ignore=tests/test_iam/test_server.py"
-    "--ignore=tests/test_iot/test_server.py"
-    "--ignore=tests/test_iotdata/test_server.py"
-    "--ignore=tests/test_kinesis/test_kinesis.py"
-    "--ignore=tests/test_kinesis/test_kinesis_cloudformation.py"
-    "--ignore=tests/test_kinesis/test_server.py"
-    "--ignore=tests/test_kinesisvideo/test_server.py"
-    "--ignore=tests/test_kinesisvideoarchivedmedia/test_server.py"
-    "--ignore=tests/test_kms/test_kms.py"
-    "--ignore=tests/test_kms/test_server.py"
-    "--ignore=tests/test_kms/test_utils.py"
-    "--ignore=tests/test_logs/test_logs.py"
-    "--ignore=tests/test_polly/test_server.py"
-    "--ignore=tests/test_rds/test_rds.py"
-    "--ignore=tests/test_rds/test_server.py"
-    "--ignore=tests/test_rds2/test_server.py"
-    "--ignore=tests/test_redshift/test_redshift.py"
-    "--ignore=tests/test_redshift/test_server.py"
-    "--ignore=tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py"
-    "--ignore=tests/test_route53/test_route53.py"
-    "--ignore=tests/test_s3/test_s3.py"
-    "--ignore=tests/test_s3/test_s3_cloudformation.py"
-    "--ignore=tests/test_s3/test_s3_lifecycle.py"
-    "--ignore=tests/test_s3/test_s3_storageclass.py"
-    "--ignore=tests/test_s3/test_s3_utils.py"
-    "--ignore=tests/test_s3bucket_path/test_s3bucket_path.py"
-    "--ignore=tests/test_s3bucket_path/test_s3bucket_path_combo.py"
-    "--ignore=tests/test_secretsmanager/test_server.py"
-    "--ignore=tests/test_ses/test_server.py"
-    "--ignore=tests/test_ses/test_ses.py"
-    "--ignore=tests/test_ses/test_ses_boto3.py"
-    "--ignore=tests/test_ses/test_ses_sns_boto3.py"
-    "--ignore=tests/test_sns/test_application.py"
-    "--ignore=tests/test_sns/test_application_boto3.py"
-    "--ignore=tests/test_sns/test_publishing.py"
-    "--ignore=tests/test_sns/test_publishing_boto3.py"
-    "--ignore=tests/test_sns/test_server.py"
-    "--ignore=tests/test_sns/test_subscriptions.py"
-    "--ignore=tests/test_sns/test_subscriptions_boto3.py"
-    "--ignore=tests/test_sns/test_topics.py"
-    "--ignore=tests/test_sns/test_topics_boto3.py"
-    "--ignore=tests/test_sqs/test_server.py"
-    "--ignore=tests/test_sqs/test_sqs.py"
-    "--ignore=tests/test_ssm/test_ssm_boto3.py"
-    "--ignore=tests/test_ssm/test_ssm_docs.py"
-    "--ignore=tests/test_sts/test_server.py"
-    "--ignore=tests/test_sts/test_sts.py"
-    "--ignore=tests/test_swf/models/test_activity_task.py"
-    "--ignore=tests/test_swf/models/test_decision_task.py"
-    "--ignore=tests/test_swf/models/test_timeout.py"
-    "--ignore=tests/test_swf/models/test_workflow_execution.py"
-    "--ignore=tests/test_swf/responses/test_activity_tasks.py"
-    "--ignore=tests/test_swf/responses/test_activity_types.py"
-    "--ignore=tests/test_swf/responses/test_decision_tasks.py"
-    "--ignore=tests/test_swf/responses/test_domains.py"
-    "--ignore=tests/test_swf/responses/test_timeouts.py"
-    "--ignore=tests/test_swf/responses/test_workflow_executions.py"
-    "--ignore=tests/test_swf/responses/test_workflow_types.py"
-    # attempts web connections
-    "--ignore=tests/test_appsync/test_appsync_schema.py"
-    "--ignore=tests/test_awslambda/test_lambda_eventsourcemapping.py"
-    "--ignore=tests/test_awslambda/test_lambda_invoke.py"
-    "--ignore=tests/test_batch/test_batch_jobs.py"
-    "--ignore=tests/**/*_integration.py"
+    "--numprocesses $NIX_BUILD_CORES"
+
+    # Disable tests that try to access the network
+    "--deselect=tests/test_cloudformation/test_cloudformation_custom_resources.py::test_create_custom_lambda_resource__verify_cfnresponse_failed"
+    "--deselect=tests/test_cloudformation/test_server.py::test_cloudformation_server_get"
+    "--deselect=tests/test_core/test_decorator_calls.py::test_context_manager"
+    "--deselect=tests/test_core/test_decorator_calls.py::test_decorator_start_and_stop"
+    "--deselect=tests/test_core/test_request_mocking.py::test_passthrough_requests"
+    "--deselect=tests/test_firehose/test_firehose_put.py::test_put_record_batch_http_destination"
+    "--deselect=tests/test_firehose/test_firehose_put.py::test_put_record_http_destination"
+    "--deselect=tests/test_logs/test_integration.py::test_put_subscription_filter_with_lambda"
+    "--deselect=tests/test_sqs/test_integration.py::test_invoke_function_from_sqs_exception"
+    "--deselect=tests/test_sqs/test_sqs_integration.py::test_invoke_function_from_sqs_exception"
+    "--deselect=tests/test_stepfunctions/test_stepfunctions.py::test_state_machine_creation_fails_with_invalid_names"
+    "--deselect=tests/test_stepfunctions/test_stepfunctions.py::test_state_machine_list_executions_with_pagination"
+
+    # json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
+    "--deselect=tests/test_cloudformation/test_cloudformation_stack_integration.py::test_lambda_function"
+  ];
+
+  disabledTestPaths = [
+    # xml.parsers.expat.ExpatError: out of memory: line 1, column 0
+    "tests/test_sts/test_sts.py"
+    # botocore.exceptions.NoCredentialsError: Unable to locate credentials
+    "tests/test_redshiftdata/test_redshiftdata.py"
+    # Tries to access the network
+    "tests/test_appsync/test_appsync_schema.py"
+    "tests/test_awslambda/test_lambda_eventsourcemapping.py"
+    "tests/test_awslambda/test_lambda_invoke.py"
+    "tests/test_batch/test_batch_jobs.py"
   ];
 
   disabledTests = [
-    # these tests rely on the network
-    "test_server"
-    "test_managedblockchain_nodes"
-    "test_swf"
-    "test_simple_instance"
-    "test_passthrough_requests"
-    "test_s3_server_get"
-    "test_s3_server_bucket_create"
-    "test_s3_server_post_to_bucket"
-    "test_s3_server_put_ipv6"
-    "test_s3_server_put_ipv4"
-    "test_http_proxying_integration"
-    "test_submit_job_by_name"
-    "test_submit_job"
-    "test_list_jobs"
-    "test_terminate_job"
-    "test_idtoken_contains_kid_header"
-    "test_latest_meta_data"
-    "test_meta_data_iam"
-    "test_meta_data_security_credentials"
-    "test_meta_data_default_role"
-    "test_reset_api"
-    "test_data_api"
-    "test_requests_to_amazon_subdomains_dont_work"
-    "test_get_records_seq"
-    "test_stream_with_range_key"
-    "test_create_notebook_instance_bad_volume_size"
-    "http_destination"
-    "test_invoke_function_from_sqs_exception"
-    "test_state_machine_list_executions_with_pagination"
-    "test_put_subscription_filter_with_lambda"
-    "test_create_custom_lambda_resource__verify_cfnresponse_failed"
-    "test_state_machine_creation_fails_with_invalid_names"
-    # needs graphql
-    "test_get_schema_creation_status"
     # only appears in aarch64 currently, but best to be safe
     "test_state_machine_list_executions_with_filter"
   ];

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "3.0.5";
+  version = "3.1.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-hfLs4K0DBaoTo5E5zmSKs6/hwEyzKsHbjV5ekRfU0Q4=";
+    sha256 = "sha256-+kgVlfVhHZ/r2vCg0Skwe1433mh2w30DXO7+Rs59isA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -71,14 +71,11 @@ buildPythonPackage rec {
 
   checkInputs = [
     freezegun
-    pytest-xdist
     pytestCheckHook
     sure
   ];
 
   pytestFlagsArray = [
-    "--numprocesses $NIX_BUILD_CORES"
-
     # Disable tests that try to access the network
     "--deselect=tests/test_cloudformation/test_cloudformation_custom_resources.py::test_create_custom_lambda_resource__verify_cfnresponse_failed"
     "--deselect=tests/test_cloudformation/test_server.py::test_cloudformation_server_get"
@@ -92,9 +89,24 @@ buildPythonPackage rec {
     "--deselect=tests/test_sqs/test_sqs_integration.py::test_invoke_function_from_sqs_exception"
     "--deselect=tests/test_stepfunctions/test_stepfunctions.py::test_state_machine_creation_fails_with_invalid_names"
     "--deselect=tests/test_stepfunctions/test_stepfunctions.py::test_state_machine_list_executions_with_pagination"
+    "--deselect=tests/test_iotdata/test_iotdata.py::test_update"
+    "--deselect=tests/test_iotdata/test_iotdata.py::test_basic"
+    "--deselect=tests/test_iotdata/test_iotdata.py::test_delete_field_from_device_shadow"
+    "--deselect=tests/test_iotdata/test_iotdata.py::test_publish"
+    "--deselect=tests/test_s3/test_server.py::test_s3_server_bucket_versioning"
 
     # json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
     "--deselect=tests/test_cloudformation/test_cloudformation_stack_integration.py::test_lambda_function"
+
+    # AssertionError: CloudWatch log event was not found.
+    "--deselect=tests/test_logs/test_integration.py::test_subscription_filter_applies_to_new_streams"
+
+    # KeyError: 'global'
+    "--deselect=tests/test_iotdata/test_server.py::test_iotdata_list"
+    "--deselect=tests/test_iotdata/test_server.py::test_publish"
+
+    # Blocks test execution
+    "--deselect=tests/test_utilities/test_threaded_server.py::TestThreadedMotoServer::test_load_data_from_inmemory_client"
   ];
 
   disabledTestPaths = [

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -35,11 +35,11 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli";
-  version = "1.22.21"; # N.B: if you change this, change botocore and boto3 to a matching version too
+  version = "1.22.35"; # N.B: if you change this, change botocore and boto3 to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-yzfy6MjXC6LeydLNVXQvcK4UmpVQP/jJ+W2jMgpNMgw=";
+    hash = "sha256-GsMclLh/VtPaNjD+XDKqTYeSX29R2aRS7If9G918OWY=";
   };
 
   # https://github.com/aws/aws-cli/issues/4837

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -35,11 +35,11 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli";
-  version = "1.22.35"; # N.B: if you change this, change botocore and boto3 to a matching version too
+  version = "1.22.67"; # N.B: if you change this, change botocore and boto3 to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-GsMclLh/VtPaNjD+XDKqTYeSX29R2aRS7If9G918OWY=";
+    hash = "sha256-ofgxL9V/jTn/itxSOLGYkAmgQXES7aVUM/vM6nWdbBc=";
   };
 
   # https://github.com/aws/aws-cli/issues/4837

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -20,17 +20,18 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli";
-  version = "1.20.54"; # N.B: if you change this, change botocore and boto3 to a matching version too
+  version = "1.22.14"; # N.B: if you change this, change botocore and boto3 to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-stnuPobBKIpKA4iTKGTO5kmMEl7grFdZNryz40S599M=";
+    sha256 = "sha256-FTGtUqdjZel8XqSrO3s3XQNqR6fyTO3mc1gyIQfk9n8=";
   };
 
   # https://github.com/aws/aws-cli/issues/4837
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "docutils>=0.10,<0.16" "docutils>=0.10"
+      --replace "docutils>=0.10,<0.16" "docutils>=0.10" \
+      --replace "rsa>=3.1.2,<4.8" "rsa<5,>=3.1.2"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -35,11 +35,11 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli";
-  version = "1.22.67"; # N.B: if you change this, change botocore and boto3 to a matching version too
+  version = "1.22.88"; # N.B: if you change this, change botocore and boto3 to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ofgxL9V/jTn/itxSOLGYkAmgQXES7aVUM/vM6nWdbBc=";
+    hash = "sha256-fwbejwcT4piC8Zr6+ubxMd+TuF9O4icOentI2GlhYrc=";
   };
 
   # https://github.com/aws/aws-cli/issues/4837

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -35,11 +35,11 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli";
-  version = "1.22.14"; # N.B: if you change this, change botocore and boto3 to a matching version too
+  version = "1.22.21"; # N.B: if you change this, change botocore and boto3 to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-FTGtUqdjZel8XqSrO3s3XQNqR6fyTO3mc1gyIQfk9n8=";
+    hash = "sha256-yzfy6MjXC6LeydLNVXQvcK4UmpVQP/jJ+W2jMgpNMgw=";
   };
 
   # https://github.com/aws/aws-cli/issues/4837

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -1,5 +1,6 @@
 { lib
 , python3
+, fetchFromGitHub
 , groff
 , less
 }:
@@ -13,6 +14,20 @@ let
           inherit version;
           sha256 = "189n8hpijy14jfan4ha9f5n06mnl33cxz7ay92wjqgkr639s0vg9";
         };
+      });
+      pyyaml = super.pyyaml.overridePythonAttrs (oldAttrs: rec {
+        version = "5.4.1";
+        src = fetchFromGitHub {
+          owner = "yaml";
+          repo = "pyyaml";
+          rev = version;
+          hash = "sha256-VUqnlOF/8zSOqh6JoEYOsfQ0P4g+eYqxyFTywgCS7gM=";
+        };
+        checkPhase = ''
+          runHook preCheck
+          PYTHONPATH="tests/lib3:$PYTHONPATH" ${self.python.interpreter} -m test_all
+          runHook postCheck
+        '';
       });
     };
   };


### PR DESCRIPTION
For better IT we need newer version of python `moto`  (AWS services mocks). In this PR we bump `moto` version and some dependencies `boto3`, `botocore`, `awscli`. These changes were cherry-picked from `22.05` tag in original `nixpkgs` repository.