### PR TITLE
build-vms: keep support for lib overlays

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -29,7 +29,7 @@ rec {
     nodes: configurations:
 
     import ./eval-config.nix {
-      inherit system specialArgs;
+      inherit system specialArgs lib;
       modules = configurations ++ extraConfigurations;
       baseModules =  (import ../modules/module-list.nix) ++
         [ ../modules/virtualisation/qemu-vm.nix


### PR DESCRIPTION
This is a backport from https://github.com/NixOS/nixpkgs/pull/235874