### PR TITLE
nixos/buildkite-agents: simplify agent module.

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -1,64 +1,49 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.services.buildkite-agents;
 
-  mkHookOption = { name, description, example ? null }: {
-    inherit name;
-    value = mkOption {
-      default = null;
-      inherit description;
-      type = types.nullOr types.lines;
-    } // (if example == null then {} else { inherit example; });
-  };
-  mkHookOptions = hooks: listToAttrs (map mkHookOption hooks);
-
-  hooksDir = cfg: let
-    mkHookEntry = name: value: ''
-      cat > $out/${name} <<'EOF'
-      #! ${pkgs.runtimeShell}
-      set -e
-      ${value}
-      EOF
-      chmod 755 $out/${name}
+  hooksDir = hooks:
+    let
+      mkHookEntry = name: text: ''
+        ln --symbolic ${pkgs.writeShellApplication { inherit name text; }}/bin/${name} $out/${name}
+      '';
+    in
+    pkgs.runCommandLocal "buildkite-agent-hooks" { } ''
+      mkdir $out
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList mkHookEntry hooks)}
     '';
-  in pkgs.runCommand "buildkite-agent-hooks" { preferLocalBuild = true; } ''
-    mkdir $out
-    ${concatStringsSep "\n" (mapAttrsToList mkHookEntry (filterAttrs (n: v: v != null) cfg.hooks))}
-  '';
 
   buildkiteOptions = { name ? "", config, ... }: {
     options = {
-      enable = mkOption {
+      enable = lib.mkOption {
         default = true;
-        type = types.bool;
+        type = lib.types.bool;
         description = "Whether to enable this buildkite agent";
       };
 
-      package = mkOption {
+      package = lib.mkOption {
         default = pkgs.buildkite-agent;
-        defaultText = literalExpression "pkgs.buildkite-agent";
+        defaultText = lib.literalExpression "pkgs.buildkite-agent";
         description = "Which buildkite-agent derivation to use";
-        type = types.package;
+        type = lib.types.package;
       };
 
-      dataDir = mkOption {
+      dataDir = lib.mkOption {
         default = "/var/lib/buildkite-agent-${name}";
         description = "The workdir for the agent";
-        type = types.str;
+        type = lib.types.str;
       };
 
-      runtimePackages = mkOption {
+      runtimePackages = lib.mkOption {
         default = [ pkgs.bash pkgs.gnutar pkgs.gzip pkgs.git pkgs.nix ];
-        defaultText = literalExpression "[ pkgs.bash pkgs.gnutar pkgs.gzip pkgs.git pkgs.nix ]";
+        defaultText = lib.literalExpression "[ pkgs.bash pkgs.gnutar pkgs.gzip pkgs.git pkgs.nix ]";
         description = "Add programs to the buildkite-agent environment";
-        type = types.listOf types.package;
+        type = lib.types.listOf lib.types.package;
       };
 
-      tokenPath = mkOption {
-        type = types.path;
+      tokenPath = lib.mkOption {
+        type = lib.types.path;
         description = ''
           The token from your Buildkite "Agents" page.
 
@@ -67,25 +52,25 @@ let
         '';
       };
 
-      name = mkOption {
-        type = types.str;
+      name = lib.mkOption {
+        type = lib.types.str;
         default = "%hostname-${name}-%n";
         description = ''
           The name of the agent as seen in the buildkite dashboard.
         '';
       };
 
-      tags = mkOption {
-        type = types.attrsOf (types.either types.str (types.listOf types.str));
-        default = {};
-        example = { queue = "default"; docker = "true"; ruby2 ="true"; };
+      tags = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.either lib.types.str (lib.types.listOf lib.types.str));
+        default = { };
+        example = { queue = "default"; docker = "true"; ruby2 = "true"; };
         description = ''
           Tags for the agent.
         '';
       };
 
-      extraConfig = mkOption {
-        type = types.lines;
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         example = "debug=true";
         description = ''
@@ -93,8 +78,8 @@ let
         '';
       };
 
-      privateSshKeyPath = mkOption {
-        type = types.nullOr types.path;
+      privateSshKeyPath = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         ## maximum care is taken so that secrets (ssh keys and the CI token)
         ## don't end up in the Nix store.
@@ -108,67 +93,25 @@ let
         '';
       };
 
-      hooks = mkHookOptions [
-        { name = "checkout";
-          description = ''
-            The `checkout` hook script will replace the default checkout routine of the
-            bootstrap.sh script. You can use this hook to do your own SCM checkout
-            behaviour
-          ''; }
-        { name = "command";
-          description = ''
-            The `command` hook script will replace the default implementation of running
-            the build command.
-          ''; }
-        { name = "environment";
-          description = ''
-            The `environment` hook will run before all other commands, and can be used
-            to set up secrets, data, etc. Anything exported in hooks will be available
-            to the build script.
+      hooks = lib.mkOption {
+        type = lib.types.attrsOf lib.types.lines;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            environment = '''
+              export SECRET_VAR=`head -1 /run/keys/secret`
+            ''';
+          }'';
+        description = ''
+          "Agent" hooks to install.
+          See <https://buildkite.com/docs/agent/v3/hooks> for possible options.
+        '';
+      };
 
-            Note: the contents of this file will be copied to the world-readable
-            Nix store.
-          '';
-          example = ''
-            export SECRET_VAR=`head -1 /run/keys/secret`
-          ''; }
-        { name = "post-artifact";
-          description = ''
-            The `post-artifact` hook will run just after artifacts are uploaded
-          ''; }
-        { name = "post-checkout";
-          description = ''
-            The `post-checkout` hook will run after the bootstrap script has checked out
-            your projects source code.
-          ''; }
-        { name = "post-command";
-          description = ''
-            The `post-command` hook will run after the bootstrap script has run your
-            build commands
-          ''; }
-        { name = "pre-artifact";
-          description = ''
-            The `pre-artifact` hook will run just before artifacts are uploaded
-          ''; }
-        { name = "pre-checkout";
-          description = ''
-            The `pre-checkout` hook will run just before your projects source code is
-            checked out from your SCM provider
-          ''; }
-        { name = "pre-command";
-          description = ''
-            The `pre-command` hook will run just before your build command runs
-          ''; }
-        { name = "pre-exit";
-          description = ''
-            The `pre-exit` hook will run just before your build job finishes
-          ''; }
-      ];
-
-      hooksPath = mkOption {
-        type = types.path;
-        default = hooksDir config;
-        defaultText = literalDocBook "generated from <option>services.buildkite-agents.&lt;name&gt;.hooks</option>";
+      hooksPath = lib.mkOption {
+        type = lib.types.path;
+        default = hooksDir config.hooks;
+        defaultText = lib.literalDocBook "generated from <option>services.buildkite-agents.&lt;name&gt;.hooks</option>";
         description = ''
           Path to the directory storing the hooks.
           Consider using <option>services.buildkite-agents.&lt;name&gt;.hooks.&lt;name&gt;</option>
@@ -176,10 +119,10 @@ let
         '';
       };
 
-      shell = mkOption {
-        type = types.str;
+      shell = lib.mkOption {
+        type = lib.types.str;
         default = "${pkgs.bash}/bin/bash -e -c";
-        defaultText = literalExpression ''"''${pkgs.bash}/bin/bash -e -c"'';
+        defaultText = lib.literalExpression ''"''${pkgs.bash}/bin/bash -e -c"'';
         description = ''
           Command that buildkite-agent 3 will execute when it spawns a shell.
         '';
@@ -190,9 +133,9 @@ let
   mapAgents = function: lib.mkMerge (lib.mapAttrsToList function enabledAgents);
 in
 {
-  options.services.buildkite-agents = mkOption {
-    type = types.attrsOf (types.submodule buildkiteOptions);
-    default = {};
+  options.services.buildkite-agents = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule buildkiteOptions);
+    default = { };
     description = ''
       Attribute set of buildkite agents.
       The attribute key is combined with the hostname and a unique integer to
@@ -213,23 +156,24 @@ in
     };
   });
   config.users.groups = mapAgents (name: cfg: {
-    "buildkite-agent-${name}" = {};
+    "buildkite-agent-${name}" = { };
   });
 
   config.systemd.services = mapAgents (name: cfg: {
-    "buildkite-agent-${name}" =
-      { description = "Buildkite Agent";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" ];
-        path = cfg.runtimePackages ++ [ cfg.package pkgs.coreutils ];
-        environment = config.networking.proxy.envVars // {
-          HOME = cfg.dataDir;
-          NIX_REMOTE = "daemon";
-        };
+    "buildkite-agent-${name}" = {
+      description = "Buildkite Agent";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      path = cfg.runtimePackages ++ [ cfg.package pkgs.coreutils ];
+      environment = config.networking.proxy.envVars // {
+        HOME = cfg.dataDir;
+        NIX_REMOTE = "daemon";
+      };
 
-        ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
-        ##     don't end up in the Nix store.
-        preStart = let
+      ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
+      ##     don't end up in the Nix store.
+      preStart =
+        let
           sshDir = "${cfg.dataDir}/.ssh";
           tagStr = name: value:
             if lib.isList value
@@ -237,44 +181,39 @@ in
             else "${name}=${value}";
           tagsStr = lib.concatStringsSep "," (lib.mapAttrsToList tagStr cfg.tags);
         in
-          optionalString (cfg.privateSshKeyPath != null) ''
-            mkdir -m 0700 -p "${sshDir}"
-            install -m600 "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
-          '' + ''
-            cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
-            token="$(cat ${toString cfg.tokenPath})"
-            name="${cfg.name}"
-            shell="${cfg.shell}"
-            tags="${tagsStr}"
-            build-path="${cfg.dataDir}/builds"
-            hooks-path="${cfg.hooksPath}"
-            ${cfg.extraConfig}
-            EOF
-          '';
+        lib.optionalString (cfg.privateSshKeyPath != null) ''
+          mkdir -m 0700 -p "${sshDir}"
+          install -m600 "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
+        '' + ''
+          cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
+          token="$(cat ${toString cfg.tokenPath})"
+          name="${cfg.name}"
+          shell="${cfg.shell}"
+          tags="${tagsStr}"
+          build-path="${cfg.dataDir}/builds"
+          hooks-path="${cfg.hooksPath}"
+          ${cfg.extraConfig}
+          EOF
+        '';
 
-        serviceConfig =
-          { ExecStart = "${cfg.package}/bin/buildkite-agent start --config ${cfg.dataDir}/buildkite-agent.cfg";
-            User = "buildkite-agent-${name}";
-            RestartSec = 5;
-            Restart = "on-failure";
-            TimeoutSec = 10;
-            # set a long timeout to give buildkite-agent a chance to finish current builds
-            TimeoutStopSec = "2 min";
-            KillMode = "mixed";
-          };
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/buildkite-agent start --config ${cfg.dataDir}/buildkite-agent.cfg";
+        User = "buildkite-agent-${name}";
+        RestartSec = 5;
+        Restart = "on-failure";
+        TimeoutSec = 10;
+        # set a long timeout to give buildkite-agent a chance to finish current builds
+        TimeoutStopSec = "2 min";
+        KillMode = "mixed";
       };
+    };
   });
 
-  config.assertions = mapAgents (name: cfg: [
-      { assertion = cfg.hooksPath == (hooksDir cfg) || all (v: v == null) (attrValues cfg.hooks);
-        message = ''
-          Options `services.buildkite-agents.${name}.hooksPath' and
-          `services.buildkite-agents.${name}.hooks.<name>' are mutually exclusive.
-        '';
-      }
-  ]);
-
-  imports = [
-    (mkRemovedOptionModule [ "services" "buildkite-agent"] "services.buildkite-agent has been upgraded from version 2 to version 3 and moved to an attribute set at services.buildkite-agents. Please consult the 20.03 release notes for more information.")
-  ];
+  config.assertions = mapAgents (name: cfg: [{
+    assertion = cfg.hooksPath != hooksDir cfg.hooks -> cfg.hooks == { };
+    message = ''
+      Options `services.buildkite-agents.${name}.hooksPath' and
+      `services.buildkite-agents.${name}.hooks.<name>' are mutually exclusive.
+    '';
+  }]);
 }


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/236778

So that we can shellcheck hooks and use new hooks.