### PR TITLE
Use newer main method

### DIFF
--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       ${lib.concatStringsSep "\n" (map (p: addJars "${p}/share/java") extraJars)}
 
       ${lib.getBin jre}/bin/java -cp "\$CP" \$JAVA_OPTS \
-        liquibase.integration.commandline.Main \''${1+"\$@"}
+        liquibase.integration.commandline.LiquibaseCommandLine \''${1+"\$@"}
       EOF
       chmod +x $out/bin/liquibase
   '';


### PR DESCRIPTION
Liquibase 4.17.2 uses a different, newer command line runner that accepts new arguments. This changes that packaging to use that method