### PR TITLE
tensorflow: pass overridden protobuf packages

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9570,6 +9570,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
     flatbuffers-core = pkgs.flatbuffers;
     flatbuffers-python = self.flatbuffers;
+    protobuf-core = pkgs.protobuf;
+    protobuf-python = pkgs.protobuf;
     lmdb-core = pkgs.lmdb;
   };
 


### PR DESCRIPTION
During a recent nixpkgs update, tensorflow got updated to 2.7.0, but we missed passing overridden `protobuf-core` and `protobuf-python`.