### PR TITLE
Backport postgresql 15

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -260,9 +260,9 @@ in self: {
   };
 
   postgresql_15 = self.callPackage generic {
-    version = "15.0";
+    version = "15.1";
     psqlSchema = "15";
-    hash = "sha256-cux09KfBbmhPQ+pC4hVJf81MVdAopo+3LpnmH/QNpNY=";
+    hash = "sha256-ZP3yPXNK+tDf5Ad9rKlqxR3NaX5ori09TKbEXLFOIa4=";
     this = self.postgresql_15;
     thisAttr = "postgresql_15";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -20,7 +20,7 @@ let
 
       # for tests
       nixosTests, thisAttr
-    }:
+    }@args:
   let
     atLeast = lib.versionAtLeast version;
     icuEnabled = atLeast "10";
@@ -151,14 +151,14 @@ let
       inherit readline psqlSchema;
 
       pkgs = let
-        scope = { postgresql = this; };
+        scope = { postgresql = this.override args; };
         newSelf = self // scope;
         newSuper = { callPackage = newScope (scope // this.pkgs); };
       in import ./packages.nix newSelf newSuper;
 
       withPackages = postgresqlWithPackages {
                        inherit makeWrapper buildEnv;
-                       postgresql = this;
+                       postgresql = this.override args;
                      }
                      this.pkgs;
 

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -263,9 +263,9 @@ in self: {
   };
 
   postgresql_15 = self.callPackage generic {
-    version = "15.1";
+    version = "15.2";
     psqlSchema = "15";
-    hash = "sha256-ZP3yPXNK+tDf5Ad9rKlqxR3NaX5ori09TKbEXLFOIa4=";
+    hash = "sha256-maIXH8PWtbX1a3V6ejy4XVCaOOQnOAXe8jlB7SuEaMc=";
     this = self.postgresql_15;
     thisAttr = "postgresql_15";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -258,4 +258,13 @@ in self: {
     thisAttr = "postgresql_14";
     inherit self;
   };
+
+  postgresql_15 = self.callPackage generic {
+    version = "15.0";
+    psqlSchema = "15";
+    hash = "sha256-cux09KfBbmhPQ+pC4hVJf81MVdAopo+3LpnmH/QNpNY=";
+    this = self.postgresql_15;
+    thisAttr = "postgresql_15";
+    inherit self;
+  };
 }

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -263,9 +263,9 @@ in self: {
   };
 
   postgresql_15 = self.callPackage generic {
-    version = "15.2";
+    version = "15.3";
     psqlSchema = "15";
-    hash = "sha256-maIXH8PWtbX1a3V6ejy4XVCaOOQnOAXe8jlB7SuEaMc=";
+    hash = "sha256-/8fUiR8A/79cP06rf7vO2EYLjA7mPFpRZxM7nmWZ2TI=";
     this = self.postgresql_15;
     thisAttr = "postgresql_15";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -265,7 +265,7 @@ in self: {
   postgresql_15 = self.callPackage generic {
     version = "15.3";
     psqlSchema = "15";
-    hash = "sha256-/8fUiR8A/79cP06rf7vO2EYLjA7mPFpRZxM7nmWZ2TI=";
+    sha256 = "sha256-/8fUiR8A/79cP06rf7vO2EYLjA7mPFpRZxM7nmWZ2TI=";
     this = self.postgresql_15;
     thisAttr = "postgresql_15";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -3,12 +3,12 @@ let
   generic =
       # dependencies
       { stdenv, lib, fetchurl, makeWrapper
-      , glibc, zlib, readline, openssl, icu, lz4, systemd, libossp_uuid
-      , pkg-config, libxml2, tzdata
+      , glibc, zlib, readline, openssl, icu, lz4, zstd, systemd, libossp_uuid
+      , pkg-config, libxml2, tzdata, libkrb5
 
       # This is important to obtain a version of `libpq` that does not depend on systemd.
       , enableSystemd ? (lib.versionAtLeast version "9.6" && !stdenv.isDarwin)
-      , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic, libkrb5
+      , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic
       , withPython ? null
 
 
@@ -25,6 +25,7 @@ let
     atLeast = lib.versionAtLeast version;
     icuEnabled = atLeast "10";
     lz4Enabled = atLeast "14";
+    zstdEnabled = atLeast "15";
 
   in stdenv.mkDerivation rec {
     pname = "postgresql";
@@ -44,6 +45,7 @@ let
       [ zlib readline openssl libxml2 ]
       ++ lib.optionals icuEnabled [ icu ]
       ++ lib.optionals lz4Enabled [ lz4 ]
+      ++ lib.optionals zstdEnabled [ zstd ]
       ++ lib.optionals enableSystemd [ systemd ]
       ++ lib.optionals gssSupport [ libkrb5 ]
       ++ lib.optionals (withPython != null) [ withPython ]
@@ -73,6 +75,7 @@ let
       (if stdenv.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
     ] ++ lib.optionals icuEnabled [ "--with-icu" ]
       ++ lib.optionals lz4Enabled [ "--with-lz4" ]
+      ++ lib.optionals zstdEnabled [ "--with-zstd" ]
       ++ lib.optionals gssSupport [ "--with-gssapi" ]
       ++ lib.optionals (withPython != null) [ "--with-python" ]
       ++ lib.optionals stdenv.hostPlatform.isRiscV [ "--disable-spinlocks" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21970,6 +21970,7 @@ with pkgs;
     postgresql_12
     postgresql_13
     postgresql_14
+    postgresql_15
   ;
   postgresql = postgresql_13.override { this = postgresql; };
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;
@@ -21977,6 +21978,7 @@ with pkgs;
   postgresql12Packages = recurseIntoAttrs postgresql_12.pkgs;
   postgresql13Packages = postgresqlPackages;
   postgresql14Packages = recurseIntoAttrs postgresql_14.pkgs;
+  postgresql15Packages = recurseIntoAttrs postgresql_15.pkgs;
 
   postgresql_jdbc = callPackage ../development/java-modules/postgresql_jdbc { };
 


### PR DESCRIPTION
```
git cherry-pick \
    fbe399529890eb555dc547d0f38e4c9ffed22d23 \
    b38cf2c9ae0402cb00540397df78d616f371e25f \
    621bb272a16599e1bf12d35dffed1840187e3b77 \
    940b7d4ee1a1008881f044cdf2986b817c753c42 \
    3abafec08f228c6c592c8d7f8b449dff00bdb702

```

But this time cherry-pick wasn't super clean. Change of default PG 13->14, drop of PG 9.6 and JIT support breaks cherry-picking.
I've tried to preserve the commits as much as possible, but we might encounter issues during upgrades