### PR TITLE
python3Packages.pymisp: add pythonImportsCheck

### DIFF
--- a/pkgs/development/python-modules/pymisp/default.nix
+++ b/pkgs/development/python-modules/pymisp/default.nix
@@ -35,6 +35,8 @@ buildPythonPackage {
     requests python-dateutil jsonschema deprecated
   ];
 
+  pythonImportsCheck = [ "pymisp" ];
+
   # testing optional email feature
   pytestFlagsArray = [ "--ignore tests/test_emailobject.py" ];
 


### PR DESCRIPTION
This PR attempts to resolve the following error
```
error: Module "pymisp"
does not explicitly export attribute "PyMISP"  [attr-defined]
    from pymisp import PyMISP
```
A normal install via pip does not yield any errors whereas the version installed via Nix does.