### PR TITLE
nixos/systemd: do not emit warning for pkgs service files

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -20,6 +20,7 @@ let
     mountToUnit
     automountToUnit
     sliceToUnit;
+
   enabledUpstreamSystemUnits = filter (n: ! elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
 
   knownEnabledServices = [ "nix-daemon" ];
@@ -167,6 +168,24 @@ let
       "local-fs.target.wants"
       "multi-user.target.wants"
       "timers.target.wants"
+    ];
+
+  serviceFilesCreatedByPackages =
+    [
+      # pkgs/os-specific/linux/nfs-utils/default.nix
+      "auth-rpcgss-module"
+      "nfs-blkmap"
+      "nfs-idmapd"
+      "rpc-gssd"
+      "rpc-statd"
+      # pkgs/os-specific/linux/zfs/default.nix
+      "zfs-mount"
+      "zfs-share"
+      "zfs-zed"
+      # pkgs/tools/virtualization/google-guest-agent/default.nix
+      "google-guest-agent"
+      "google-shutdown-scripts"
+      "google-startup-scripts"
     ];
 
   proxy_env = config.networking.proxy.envVars;
@@ -430,6 +449,7 @@ in
               || svc.serviceConfig?ExecStop;
             templateUnit = builtins.match "^(.*@).*" name;
             template = builtins.elemAt templateUnit 0;
+
           in
             concatLists [
               (optional (type == "oneshot" && (restart == "always" || restart == "on-success"))
@@ -442,13 +462,15 @@ in
                 "Service '${name}.service' has both 'reloadIfChanged' and 'reloadTriggers' set. This is probably not what you want, because 'reloadTriggers' behave the same whay as 'restartTriggers' if 'reloadIfChanged' is set."
               )
               (optional
-                (service.enable
+                ( service.enable
                   && !hasStartCmd service
                   && !(lib.elem name knownEnabledServices)
                   && !(!isNull templateUnit && cfg.services?${template} && hasStartCmd cfg.services.${template})
                   && !(lib.elem "${name}.service" enabledUpstreamSystemUnits)
-                  && builtins.all (p: isNull ((builtins.match "^${name}.*") p.name)) cfg.packages)
-                "Service `${name}' is enabled and missing a `script' or one of ExecStart, ExecStop or SuccessAction.")
+                  && builtins.all (p: isNull ((builtins.match "^${name}.*") p.name)) cfg.packages
+                  && !(lib.elem name serviceFilesCreatedByPackages))
+                "Service `${name}.service' is enabled and missing a `script' or one of ExecStart, ExecStop or SuccessAction."
+              )
             ]
         )
         cfg.services


### PR DESCRIPTION
Some service are generated as package outputs instead of by the systemd module. Fix warnings that were inproperly firing for some of those service.