### PR TITLE
[backport] python3Packages.pytest-reverse: init at 1.7.0

### DIFF
--- a/pkgs/development/python-modules/pytest-reverse/default.nix
+++ b/pkgs/development/python-modules/pytest-reverse/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, pytest
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-reverse";
+  version = "1.7.0";
+  format = "pyproject";
+
+  disable = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "adamchainz";
+    repo = "pytest-reverse";
+    rev = version;
+    hash = "sha256-r0aSbUgArHQkpaXUvMT6oyOxEliQRtSGuDt4IILzhH4=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  buildInputs = [ pytest ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytest_reverse" ];
+
+  meta = with lib; {
+    description = "Pytest plugin to reverse test order";
+    homepage = "https://github.com/adamchainz/pytest-reverse";
+    changelog = "https://github.com/adamchainz/pytest-reverse/blob/${version}/CHANGELOG.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mbalatsko ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8255,6 +8255,8 @@ in {
 
   pytest-randomly = callPackage ../development/python-modules/pytest-randomly { };
 
+  pytest-reverse = callPackage ../development/python-modules/pytest-reverse { };
+
   pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };
 
   pytest-regressions = callPackage ../development/python-modules/pytest-regressions { };


### PR DESCRIPTION
Backport of `pytest-reverse` from upstream. PR: https://github.com/NixOS/nixpkgs/pull/256474

```
git cherry-pick b25543f889b925aa1765b34817e13061b8a23f5d
```