### PR TITLE
drop! qemu-vm: Raise memory limit of bootloader build

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -204,6 +204,7 @@ let
                       + lib.optionalString cfg.useEFIBoot (
                         " -drive if=pflash,format=raw,unit=0,readonly=on,file=${efiFirmware}"
                       + " -drive if=pflash,format=raw,unit=1,file=$efiVars");
+          memSize = 1024;
         }
         ''
           # Create a /boot EFI partition with 60M and arbitrary but fixed GUIDs for reproducibility


### PR DESCRIPTION
This was causing oom issues during builds

see MONAPP-33720

This fix can be dropped once 76c7b656bfa9b20a4172f7901285560db4c2c695 is available