### PR TITLE
[backport] python3Packages.sentence-transformers: init at 2.2.2

### DIFF
--- a/pkgs/development/python-modules/huggingface-hub/default.nix
+++ b/pkgs/development/python-modules/huggingface-hub/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "huggingface-hub";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "huggingface_hub";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-jR4aqMAAQJ5a7pOe3RpCtLgdm5JVVSPsBQtube6FeqM=";
+    sha256 = "sha256-GUe9+Z23vt3sfpntDnToMY5vWLK6m0zRySSJgMljetg=";
   };
 
   nativeBuildInputs = [ packaging ];

--- a/pkgs/development/python-modules/huggingface-hub/default.nix
+++ b/pkgs/development/python-modules/huggingface-hub/default.nix
@@ -15,32 +15,39 @@
 buildPythonPackage rec {
   pname = "huggingface-hub";
   version = "0.7.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "huggingface_hub";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-GUe9+Z23vt3sfpntDnToMY5vWLK6m0zRySSJgMljetg=";
+    hash = "sha256-GUe9+Z23vt3sfpntDnToMY5vWLK6m0zRySSJgMljetg=";
   };
-
-  nativeBuildInputs = [ packaging ];
 
   propagatedBuildInputs = [
     filelock
+    packaging
     pyyaml
     requests
     ruamel-yaml
     tqdm
     typing-extensions
-  ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
 
   # Tests require network access.
   doCheck = false;
-  pythonImportsCheck = [ "huggingface_hub" ];
+
+  pythonImportsCheck = [
+    "huggingface_hub"
+  ];
 
    meta = with lib; {
-    homepage = "https://github.com/huggingface/huggingface_hub";
     description = "Download and publish models and other files on the huggingface.co hub";
+    homepage = "https://github.com/huggingface/huggingface_hub";
     changelog = "https://github.com/huggingface/huggingface_hub/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];

--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -8,7 +8,7 @@
 , scipy
 , sentencepiece
 , tokenizers
-, torch
+, pytorch
 , torchvision
 , tqdm
 , transformers
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     scipy
     sentencepiece
     tokenizers
-    torch
+    pytorch
     torchvision
     tqdm
     transformers

--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, huggingface-hub
+, nltk
+, numpy
+, scikit-learn
+, scipy
+, sentencepiece
+, tokenizers
+, torch
+, torchvision
+, tqdm
+, transformers
+}:
+
+buildPythonPackage rec {
+  pname = "sentence-transformers";
+  version = "2.2.2";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "UKPLab";
+    repo = "sentence-transformers";
+    rev = "v${version}";
+    hash = "sha256-hEYpDAL0lliaS1j+c5vaZ0q1hw802jfTUurx/FvgY9w=";
+  };
+
+  propagatedBuildInputs = [
+    huggingface-hub
+    nltk
+    numpy
+    scikit-learn
+    scipy
+    sentencepiece
+    tokenizers
+    torch
+    torchvision
+    tqdm
+    transformers
+  ];
+
+  pythonImportsCheck = [ "sentence_transformers" ];
+
+  doCheck = false; # tests fail at build_ext
+
+  meta = with lib; {
+    description = "Multilingual Sentence & Image Embeddings with BERT";
+    homepage = "https://github.com/UKPLab/sentence-transformers";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9449,6 +9449,8 @@ in {
     inherit (pkgs) sentencepiece;
   };
 
+  sentence-transformers = callPackage ../development/python-modules/sentence-transformers { };
+
   sentinel = callPackage ../development/python-modules/sentinel { };
 
   sentinels = callPackage ../development/python-modules/sentinels { };


### PR DESCRIPTION
We needed to update `huggingface-hub` because of the missing package in `propagatedBuildInputs`. Also, we needed to rename `torch` to `pytorch` as we currently have an older version than upstream.

Cherry-pick command:
```
git cherry-pick \
     bec4b99baad961400eb64a00a78211debe1e091a \
     e9ad7e5feca8a185cb28363b9e33d9fbe7ba6624 \
     500b491a25e8f0838c077f528d2cce661df9ecba
```