### PR TITLE
[backport] python3Packages.aws_secretsmanager_caching: init at 1.1.1.5

### DIFF
--- a/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
+++ b/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
+, setuptools
 , setuptools-scm
 , botocore
 , pytestCheckHook
@@ -25,6 +26,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     botocore
+    setuptools  # Needs pkg_resources at runtime.
   ];
 
   patches = [

--- a/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
+++ b/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, setuptools-scm
+, botocore
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "aws_secretsmanager_caching";
+  version = "1.1.1.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5cee2762bb89b72f3e5123feee8e45fbe44ffe163bfca08b28f27b2e2b7772e1";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    botocore
+  ];
+
+  patches = [
+    # Remove coverage tests from the pytest invocation in setup.cfg.
+    ./remove-coverage-tests.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'," ""
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Integration tests require networking.
+    "test/integ"
+  ];
+
+  pythonImportsCheck = [
+    "aws_secretsmanager_caching"
+  ];
+
+  meta = with lib; {
+    description = "Client-side AWS secrets manager caching library";
+    homepage = "https://github.com/aws/aws-secretsmanager-caching-python";
+    changelog = "https://github.com/aws/aws-secretsmanager-caching-python/releases/tag/v${version}";
+    longDescription = ''
+      The AWS Secrets Manager Python caching client enables in-process caching of secrets for Python applications.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tomaskala ];
+  };
+}

--- a/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
+++ b/pkgs/development/python-modules/aws-secretsmanager-caching/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
       --replace "'pytest-runner'," ""
   '';
 
-  nativeCheckInputs = [
+  checkInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/aws-secretsmanager-caching/remove-coverage-tests.patch
+++ b/pkgs/development/python-modules/aws-secretsmanager-caching/remove-coverage-tests.patch
@@ -1,0 +1,14 @@
+diff --git a/setup.cfg b/setup.cfg
+index 5aa81b2..0c02ded 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -3,9 +3,6 @@ xfail_strict = true
+ addopts = 
+ 	--verbose
+ 	--doctest-modules
+-	--cov aws_secretsmanager_caching
+-	--cov-fail-under 90
+-	--cov-report term-missing
+ 	--ignore doc/
+ 
+ [aliases]

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -846,6 +846,8 @@ in {
 
   aws-sam-translator = callPackage ../development/python-modules/aws-sam-translator { };
 
+  aws-secretsmanager-caching = callPackage ../development/python-modules/aws-secretsmanager-caching { };
+
   aws-xray-sdk = callPackage ../development/python-modules/aws-xray-sdk { };
 
   awscrt = callPackage ../development/python-modules/awscrt {


### PR DESCRIPTION
We have this package maintained in `end-to-end` and never backported.

Cherry-pick command:
```
git cherry-pick f02865c040a2b279bdd4a12c8dba12159009e90d e035bf06c5ccd65fe0c2b19bfacfb0d130db0858
```