### PR TITLE
[backport] python3Packages.graynoise: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/greynoise/0001-drop-ipaddress-from-requirements.patch
+++ b/pkgs/development/python-modules/greynoise/0001-drop-ipaddress-from-requirements.patch
@@ -1,0 +1,37 @@
+From f2ef61e2559247f48a7ef52cd73969f2426cca69 Mon Sep 17 00:00:00 2001
+From: Maksym Balatsko <mbalatsko@gmail.com>
+Date: Sat, 30 Sep 2023 15:01:26 +0000
+Subject: [PATCH] drop ipaddress from requirements
+
+---
+ requirements/common.txt | 1 -
+ setup.py                | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/requirements/common.txt b/requirements/common.txt
+index 8b3ba21..d745e30 100644
+--- a/requirements/common.txt
++++ b/requirements/common.txt
+@@ -5,7 +5,6 @@ colorama==0.4.6
+ click-default-group==1.2.2
+ click-repl==0.2.0
+ dict2xml==1.7.3;python_version>='3'
+-ipaddress==1.0.23
+ jinja2==3.1.2;python_version>='3.6'
+ more-itertools==9.1.0;python_version>='3'
+ requests==2.28.2
+diff --git a/setup.py b/setup.py
+index 7a7bd1f..4de0f1f 100755
+--- a/setup.py
++++ b/setup.py
+@@ -19,7 +19,6 @@ INSTALL_REQUIRES = [
+     "click-default-group",
+     "click-repl",
+     "dict2xml",
+-    "ipaddress",
+     "jinja2",
+     "more-itertools",
+     "requests",
+-- 
+2.36.1
+

--- a/pkgs/development/python-modules/greynoise/default.nix
+++ b/pkgs/development/python-modules/greynoise/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     six
   ];
 
-  nativeCheckInputs = [
+  checkInputs = [
     pytestCheckHook
     mock
   ];

--- a/pkgs/development/python-modules/greynoise/default.nix
+++ b/pkgs/development/python-modules/greynoise/default.nix
@@ -31,6 +31,11 @@ buildPythonPackage rec {
     hash = "sha256-zevom7JqXnZuotXfGtfPOmQNh32dANS4Uc6tHUuq08s=";
   };
 
+  patches = [
+    # https://github.com/GreyNoise-Intelligence/pygreynoise/pull/788
+    ./0001-drop-ipaddress-from-requirements.patch
+  ];
+
   propagatedBuildInputs = [
     click
     ansimarkup

--- a/pkgs/development/python-modules/greynoise/default.nix
+++ b/pkgs/development/python-modules/greynoise/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, click
+, ansimarkup
+, cachetools
+, colorama
+, click-default-group
+, click-repl
+, dict2xml
+, jinja2
+, more-itertools
+, requests
+, six
+, pytestCheckHook
+, mock
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "greynoise";
+  version = "2.0.1";
+  format = "setuptools";
+
+  disable = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "GreyNoise-Intelligence";
+    repo = "pygreynoise";
+    rev = "v${version}";
+    hash = "sha256-zevom7JqXnZuotXfGtfPOmQNh32dANS4Uc6tHUuq08s=";
+  };
+
+  propagatedBuildInputs = [
+    click
+    ansimarkup
+    cachetools
+    colorama
+    click-default-group
+    click-repl
+    dict2xml
+    jinja2
+    more-itertools
+    requests
+    six
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    mock
+  ];
+
+  pythonImportsCheck = [ "greynoise" ];
+
+  meta = with lib; {
+    description = "Python3 library and command line for GreyNoise";
+    homepage = "https://github.com/GreyNoise-Intelligence/pygreynoise";
+    changelog = "https://github.com/GreyNoise-Intelligence/pygreynoise/blob/${src.rev}/CHANGELOG.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mbalatsko ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3721,6 +3721,8 @@ in {
 
   gremlinpython = callPackage ../development/python-modules/gremlinpython { };
 
+  greynoise = callPackage ../development/python-modules/greynoise { };
+
   growattserver = callPackage ../development/python-modules/growattserver { };
 
   gridnet = callPackage ../development/python-modules/gridnet { };


### PR DESCRIPTION
Not really sure why we need to remove `ipaddress` dependency in our nixpkgs, it was building fine on upstream

Cherry-pick command:
```
git cherry-pick b497433b56e2a418d131d82ef849a02491f19851
```