### PR TITLE
[backport] python3Packages.hyperscan: init at 0.6.0

### DIFF
--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -51,8 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@" "includedir=@CMAKE_INSTALL_INCLUDEDIR@"
   '';
 
-  doCheck = true;
-  checkPhase = ''
+  doInstallCheck = true;
+  installCheckPhase = ''
     runHook preCheck
 
     bin/unit-hyperscan

--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DFAT_RUNTIME=ON"
     "-DBUILD_AVX512=ON"
   ]
+  ++ lib.optional (!stdenv.isDarwin) "-DFAT_RUNTIME=ON"
   ++ lib.optional (withStatic) "-DBUILD_STATIC_AND_SHARED=ON"
   ++ lib.optional (!withStatic) "-DBUILD_SHARED_LIBS=ON";
 
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     homepage = "https://www.hyperscan.io/";
     maintainers = with maintainers; [ avnik ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     license = licenses.bsd3;
   };
 })

--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -41,6 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@" "includedir=@CMAKE_INSTALL_INCLUDEDIR@"
   '';
 
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    bin/unit-hyperscan
+
+    runHook postCheck
+  '';
+
   meta = with lib; {
     description = "High-performance multiple regex matching library";
     longDescription = ''

--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -9,25 +9,22 @@
 #         which is fixed 8.41 version requirement (nixpkgs have 8.42+, and
 #         I not see any reason (for now) to backport 8.41.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hyperscan";
-  version = "5.4.0";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "intel";
-    repo = pname;
-    sha256 = "sha256-AJAjaXVnGqIlMk+gb6lpTLUdZr8nxn2XSW4fj6j/cmk=";
-    rev = "v${version}";
+    repo = "hyperscan";
+    hash = "sha256-tzmVc6kJPzkFQLUM1MttQRLpgs0uckbV6rCxEZwk1yk=";
+    rev = "v${finalAttrs.version}";
   };
 
   outputs = [ "out" "dev" ];
 
   buildInputs = [ boost ];
   nativeBuildInputs = [
-    cmake ragel python3
-    # Consider simply using busybox for these
-    # Need at least: rev, sed, cut, nm
-    util-linux
+    cmake ragel python3 util-linux
   ];
 
   cmakeFlags = [
@@ -36,14 +33,6 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional (withStatic) "-DBUILD_STATIC_AND_SHARED=ON"
   ++ lib.optional (!withStatic) "-DBUILD_SHARED_LIBS=ON";
-
-  patches = [
-    (fetchpatch {
-      # part of https://github.com/intel/hyperscan/pull/336
-      url = "https://github.com/intel/hyperscan/commit/e2c4010b1fc1272cab816ba543940b3586e68a0c.patch";
-      sha256 = "sha256-doVNwROL6MTcgOW8jBwGTnxe0zvxjawiob/g6AvXLak=";
-    })
-  ];
 
   postPatch = ''
     sed -i '/examples/d' CMakeLists.txt
@@ -69,7 +58,7 @@ stdenv.mkDerivation rec {
 
     homepage = "https://www.hyperscan.io/";
     maintainers = with maintainers; [ avnik ];
-    platforms = [ "x86_64-linux" ]; # can't find nm on darwin ; might build on aarch64 but untested
+    platforms = [ "x86_64-linux" ];
     license = licenses.bsd3;
   };
-}
+})

--- a/pkgs/development/python-modules/hyperscan/default.nix
+++ b/pkgs/development/python-modules/hyperscan/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, pkgs
+, buildPythonPackage
+, fetchFromGitHub
+, pdm-backend
+, setuptools
+, wheel
+, pcre
+, pkg-config
+, pytestCheckHook
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "hyperscan";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "darvid";
+    repo = "python-hyperscan";
+    rev = "v${version}";
+    hash = "sha256-6PoV9rY9CkXkAMWN2QCnfU4S0OJD/6bzkqFgvEVqNjo=";
+  };
+
+  buildInputs = [
+    (pkgs.hyperscan.override { withStatic = true; })
+    # we need static pcre to be built, by default only shared library is built
+    (pcre.overrideAttrs { dontDisableStatic = 0; })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    pdm-backend
+    setuptools
+    wheel
+  ];
+
+  pythonImportsCheck = [ "hyperscan" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  meta = with lib; {
+    description = "A CPython extension for the Hyperscan regular expression matching library";
+    homepage = "https://github.com/darvid/python-hyperscan";
+    changelog = "https://github.com/darvid/python-hyperscan/blob/${src.rev}/CHANGELOG.md";
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ mbalatsko ];
+  };
+}

--- a/pkgs/development/python-modules/hyperscan/default.nix
+++ b/pkgs/development/python-modules/hyperscan/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   buildInputs = [
     (pkgs.hyperscan.override { withStatic = true; })
     # we need static pcre to be built, by default only shared library is built
-    (pcre.overrideAttrs { dontDisableStatic = 0; })
+    (pcre.overrideAttrs (finalAttrs: previousAttrs: { dontDisableStatic = 0; }))
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/hyperscan/default.nix
+++ b/pkgs/development/python-modules/hyperscan/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hyperscan" ];
 
-  nativeCheckInputs = [
+  checkInputs = [
     pytestCheckHook
     pytest-mock
   ];

--- a/pkgs/development/python-modules/pdm-backend/default.nix
+++ b/pkgs/development/python-modules/pdm-backend/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+
+# propagates
+, importlib-metadata
+
+# tests
+, editables
+, git
+, pytestCheckHook
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "pdm-backend";
+  version = "2.0.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "pdm-project";
+    repo = "pdm-backend";
+    rev = "refs/tags/${version}";
+    hash = "sha256-3Wgc4kKQcE2FzfcqTs9jtfJ1Oj+qtHiDM4q8KuMNAak=";
+  };
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
+  ];
+
+  pythonImportsCheck = [
+    "pdm.backend"
+  ];
+
+  nativeCheckInputs = [
+    editables
+    git
+    pytestCheckHook
+    setuptools
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/pdm-project/pdm-backend";
+    changelog = "https://github.com/pdm-project/pdm-backend/releases/tag/${version}";
+    description = "Yet another PEP 517 backend.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4054,6 +4054,8 @@ in {
 
   hyperframe = callPackage ../development/python-modules/hyperframe { };
 
+  hyperscan = callPackage ../development/python-modules/hyperscan { };
+
   hyperion-py = callPackage ../development/python-modules/hyperion-py { };
 
   hyperlink = callPackage ../development/python-modules/hyperlink { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6279,6 +6279,8 @@ in {
 
   pdfx = callPackage ../development/python-modules/pdfx { };
 
+  pdm-backend = callPackage ../development/python-modules/pdm-backend { };
+
   pdm-pep517 = callPackage ../development/python-modules/pdm-pep517 { };
 
   pdoc3 = callPackage ../development/python-modules/pdoc3 { };


### PR DESCRIPTION
I had to vendor:
- `python3Packages.hyperscan`: `[nativeCheckInputs -> checkInputs](https://github.com/awakesecurity/nixpkgs/commit/179c42876f40b09282e1bdebcf5066aff59d5503), [use older overrideAttrs format](https://github.com/awakesecurity/nixpkgs/commit/5548c9f23dcd1bcac0e8442bf74d4b0a20b64af8)
- `hyperscan`: [checkPhase -> installCheckPhase](https://github.com/awakesecurity/nixpkgs/commit/09446d1e6347a562ac47b2757f27978ffd5cf91b). In `checkPhase` it failed: `bin/unit-hyperscan: error while loading shared libraries: libhs.so.5: cannot open shared object file: No such file or directory`, but in `installCheckPhase` and in final derivation this file exists. @jsoo1 have you seen something like that before? Are you ok with this change?