### PR TITLE
libressl: 3.5.2 -> 3.7.3

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -12,7 +12,13 @@ let
     then "DYLD_LIBRARY_PATH"
     else "LD_LIBRARY_PATH";
 
-  generic = { version, hash, patches ? [] }: stdenv.mkDerivation rec {
+  generic =
+    { version
+    , hash
+    , patches ? []
+    , knownVulnerabilities ? []
+    }: stdenv.mkDerivation rec
+  {
     pname = "libressl";
     inherit version;
 
@@ -80,6 +86,7 @@ let
       license = with licenses; [ publicDomain bsdOriginal bsd0 bsd3 gpl3 isc openssl ];
       platforms   = platforms.all;
       maintainers = with maintainers; [ thoughtpolice fpletz ];
+      knownVulnerabilities = knownVulnerabilities;
     };
   };
 
@@ -87,6 +94,10 @@ in {
   libressl_3_4 = generic {
     version = "3.4.3";
     hash = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
+    knownVulnerabilities = [
+      "Support ended 2022-10-14."
+      "https://marc.info/?l=libressl&m=167582148932407&w=2"
+    ];
   };
 
   libressl_3_5 = generic {

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -92,8 +92,8 @@ let
 
 in {
   libressl_3_6 = generic {
-    version = "3.6.2";
-    hash = "sha256-S+gP/wc3Rs9QtKjlur4nlayumMaxMqngJRm0Rd+/0DM=";
+    version = "3.6.3";
+    hash = "sha256-h7G7426e7I0K5fBMg9NrLFsOWBeEx+sIFwJe0p6t6jc=";
   };
 
   libressl_3_7 = generic {

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -97,7 +97,7 @@ in {
   };
 
   libressl_3_7 = generic {
-    version = "3.7.2";
-    hash = "sha256-sGqlOP78nGszxNtJMaCaX1LZ0jVyGa/L/32T/hLr9vc=";
+    version = "3.7.3";
+    hash = "sha256-eUjIVqkMglvXJotvhWdKjc0lS65C4iF4GyTj+NwzXbM=";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -111,4 +111,9 @@ in {
     version = "3.6.2";
     hash = "sha256-S+gP/wc3Rs9QtKjlur4nlayumMaxMqngJRm0Rd+/0DM=";
   };
+
+  libressl_3_7 = generic {
+    version = "3.7.2";
+    hash = "sha256-sGqlOP78nGszxNtJMaCaX1LZ0jVyGa/L/32T/hLr9vc=";
+  };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -104,16 +104,7 @@ in {
   };
 
   libressl_3_6 = generic {
-    version = "3.6.0";
-    hash = "sha256-GxLe/Lvb2+2oaSnkIQAK8PQjM63UgX/SbA2aGuxHhAQ=";
-
-    patches = [
-      # Fix endianness detection on aarch64-darwin, issue #181187
-      (fetchpatch {
-        name = "fix-endian-header-detection.patch";
-        url = "https://patch-diff.githubusercontent.com/raw/libressl-portable/portable/pull/771.patch";
-        sha256 = "sha256-in5U6+sl0HB9qMAtUL6Py4X2rlv0HsqRMIQhhM1oThE=";
-      })
-    ];
+    version = "3.6.1";
+    hash = "sha256-rPrGExbpO5GcKNYtUwN8pzTehcRrTXA/Gf2Dlc8AZ3Q=";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -90,8 +90,8 @@ in {
   };
 
   libressl_3_5 = generic {
-    version = "3.5.3";
-    hash = "sha256-OrXl6u9pziDGsXDuZNeFtCI19I8uYrCV/KXXtmcriyg=";
+    version = "3.5.4";
+    hash = "sha256-A3naE0Si9xrUpOO+MO+dgu7N3Of43CrmZjGh3+FDQ6w=";
 
     patches = [
       # Fix endianness detection on aarch64-darwin, issue #181187

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -107,20 +107,6 @@ in {
     ];
   };
 
-  libressl_3_5 = generic {
-    version = "3.5.4";
-    hash = "sha256-A3naE0Si9xrUpOO+MO+dgu7N3Of43CrmZjGh3+FDQ6w=";
-
-    patches = [
-      # Fix endianness detection on aarch64-darwin, issue #181187
-      (fetchpatch {
-        name = "fix-endian-header-detection.patch";
-        url = "https://patch-diff.githubusercontent.com/raw/libressl-portable/portable/pull/771.patch";
-        sha256 = "sha256-in5U6+sl0HB9qMAtUL6Py4X2rlv0HsqRMIQhhM1oThE=";
-      })
-    ];
-  };
-
   libressl_3_6 = generic {
     version = "3.6.2";
     hash = "sha256-S+gP/wc3Rs9QtKjlur4nlayumMaxMqngJRm0Rd+/0DM=";

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -91,22 +91,6 @@ let
   };
 
 in {
-  libressl_3_4 = generic {
-    version = "3.4.3";
-    hash = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
-    knownVulnerabilities = [ "Support ended 2022-10-14." ];
-    patches = [
-      (fetchpatch {
-        # https://marc.info/?l=libressl&m=167582148932407&w=2
-        name = "backport-type-confusion-fix.patch";
-        url = "https://raw.githubusercontent.com/libressl/portable/30dc760ed1d7c70766b135500950d8ca9d17b13a/patches/x509_genn.c.diff";
-        sha256 = "sha256-N9jsOueqposDWZwaR+n/v/cHgNiZbZ644d8/wKjN2/M=";
-        stripLen = 2;
-        extraPrefix = "crypto/";
-      })
-    ];
-  };
-
   libressl_3_6 = generic {
     version = "3.6.2";
     hash = "sha256-S+gP/wc3Rs9QtKjlur4nlayumMaxMqngJRm0Rd+/0DM=";

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -86,7 +86,7 @@ let
       license = with licenses; [ publicDomain bsdOriginal bsd0 bsd3 gpl3 isc openssl ];
       platforms   = platforms.all;
       maintainers = with maintainers; [ thoughtpolice fpletz ];
-      knownVulnerabilities = knownVulnerabilities;
+      inherit knownVulnerabilities;
     };
   };
 
@@ -94,9 +94,16 @@ in {
   libressl_3_4 = generic {
     version = "3.4.3";
     hash = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
-    knownVulnerabilities = [
-      "Support ended 2022-10-14."
-      "https://marc.info/?l=libressl&m=167582148932407&w=2"
+    knownVulnerabilities = [ "Support ended 2022-10-14." ];
+    patches = [
+      (fetchpatch {
+        # https://marc.info/?l=libressl&m=167582148932407&w=2
+        name = "backport-type-confusion-fix.patch";
+        url = "https://raw.githubusercontent.com/libressl/portable/30dc760ed1d7c70766b135500950d8ca9d17b13a/patches/x509_genn.c.diff";
+        sha256 = "sha256-N9jsOueqposDWZwaR+n/v/cHgNiZbZ644d8/wKjN2/M=";
+        stripLen = 2;
+        extraPrefix = "crypto/";
+      })
     ];
   };
 

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -104,7 +104,7 @@ in {
   };
 
   libressl_3_6 = generic {
-    version = "3.6.1";
-    hash = "sha256-rPrGExbpO5GcKNYtUwN8pzTehcRrTXA/Gf2Dlc8AZ3Q=";
+    version = "3.6.2";
+    hash = "sha256-S+gP/wc3Rs9QtKjlur4nlayumMaxMqngJRm0Rd+/0DM=";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -62,7 +62,7 @@ let
       ''}
     '';
 
-    doCheck = true;
+    doCheck = !stdenv.hostPlatform.isPower64;
     preCheck = ''
       export PREVIOUS_${ldLibPathEnvName}=$${ldLibPathEnvName}
       export ${ldLibPathEnvName}="$${ldLibPathEnvName}:$(realpath tls/):$(realpath ssl/):$(realpath crypto/)"

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -62,7 +62,7 @@ let
       ''}
     '';
 
-    doCheck = !stdenv.hostPlatform.isPower64;
+    doCheck = !(stdenv.hostPlatform.isPower64 || stdenv.hostPlatform.isRiscV);
     preCheck = ''
       export PREVIOUS_${ldLibPathEnvName}=$${ldLibPathEnvName}
       export ${ldLibPathEnvName}="$${ldLibPathEnvName}:$(realpath tls/):$(realpath ssl/):$(realpath crypto/)"

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -92,5 +92,14 @@ in {
   libressl_3_5 = generic {
     version = "3.5.3";
     hash = "sha256-OrXl6u9pziDGsXDuZNeFtCI19I8uYrCV/KXXtmcriyg=";
+
+    patches = [
+      # Fix endianness detection on aarch64-darwin, issue #181187
+      (fetchpatch {
+        name = "fix-endian-header-detection.patch";
+        url = "https://patch-diff.githubusercontent.com/raw/libressl-portable/portable/pull/771.patch";
+        sha256 = "sha256-in5U6+sl0HB9qMAtUL6Py4X2rlv0HsqRMIQhhM1oThE=";
+      })
+    ];
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -12,13 +12,13 @@ let
     then "DYLD_LIBRARY_PATH"
     else "LD_LIBRARY_PATH";
 
-  generic = { version, sha256, patches ? [] }: stdenv.mkDerivation rec {
+  generic = { version, hash, patches ? [] }: stdenv.mkDerivation rec {
     pname = "libressl";
     inherit version;
 
     src = fetchurl {
       url = "mirror://openbsd/LibreSSL/${pname}-${version}.tar.gz";
-      inherit sha256;
+      inherit hash;
     };
 
     nativeBuildInputs = [ cmake ];
@@ -86,11 +86,11 @@ let
 in {
   libressl_3_4 = generic {
     version = "3.4.3";
-    sha256 = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
+    hash = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
   };
 
   libressl_3_5 = generic {
-    version = "3.5.2";
-    sha256 = "sha256-Vv6rjiHD+mVJ+LfXURZYuOmFGBYoOKeVMUcyZUrfPl8=";
+    version = "3.5.3";
+    hash = "sha256-OrXl6u9pziDGsXDuZNeFtCI19I8uYrCV/KXXtmcriyg=";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -102,4 +102,18 @@ in {
       })
     ];
   };
+
+  libressl_3_6 = generic {
+    version = "3.6.0";
+    hash = "sha256-GxLe/Lvb2+2oaSnkIQAK8PQjM63UgX/SbA2aGuxHhAQ=";
+
+    patches = [
+      # Fix endianness detection on aarch64-darwin, issue #181187
+      (fetchpatch {
+        name = "fix-endian-header-detection.patch";
+        url = "https://patch-diff.githubusercontent.com/raw/libressl-portable/portable/pull/771.patch";
+        sha256 = "sha256-in5U6+sl0HB9qMAtUL6Py4X2rlv0HsqRMIQhhM1oThE=";
+      })
+    ];
+  };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -696,6 +696,7 @@ mapAliases ({
   librdf = lrdf; # Added 2020-03-22
   librecad2 = throw "'librecad2' has been renamed to/replaced by 'librecad'"; # Converted to throw 2022-02-22
   libressl_3_2 = throw "'libressl_3_2' has reached end-of-life "; # Added 2022-03-19
+  libressl_3_5 = throw "'libressl_3_5' has reached end-of-life "; # Added 2023-05-07
   librsync_0_9 = throw "librsync_0_9 has been removed"; # Added 2021-07-24
   libseat = seatd; # Added 2021-06-24
   libstdcxxHook = throw "libstdcxx hook has been removed because cc-wrapper is now directly aware of the c++ standard library intended to be used"; # Added 2020-06-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19984,7 +19984,6 @@ with pkgs;
 
   inherit (callPackages ../development/libraries/libressl { })
     libressl_3_4
-    libressl_3_5
     libressl_3_6;
 
   libressl = libressl_3_6;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19983,7 +19983,6 @@ with pkgs;
   openvdb = callPackage ../development/libraries/openvdb {};
 
   inherit (callPackages ../development/libraries/libressl { })
-    libressl_3_4
     libressl_3_6
     libressl_3_7;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19984,9 +19984,10 @@ with pkgs;
 
   inherit (callPackages ../development/libraries/libressl { })
     libressl_3_4
-    libressl_3_5;
+    libressl_3_5
+    libressl_3_6;
 
-  libressl = libressl_3_4;
+  libressl = libressl_3_6;
 
   boringssl = callPackage ../development/libraries/boringssl { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19984,9 +19984,10 @@ with pkgs;
 
   inherit (callPackages ../development/libraries/libressl { })
     libressl_3_4
-    libressl_3_6;
+    libressl_3_6
+    libressl_3_7;
 
-  libressl = libressl_3_6;
+  libressl = libressl_3_7;
 
   boringssl = callPackage ../development/libraries/boringssl { };
 
@@ -34894,6 +34895,7 @@ with pkgs;
 
   wasm-pack = callPackage ../development/tools/wasm-pack {
     inherit (darwin.apple_sdk.frameworks) Security;
+    libressl = libressl_3_6;
   };
 
   wavegain = callPackage ../applications/audio/wavegain { };


### PR DESCRIPTION
Fixes:
* CVE-2022-48437
* CVE-2023-35784
