### PR TITLE
fribidi: 1.0.10 -> 1.0.13

### DIFF
--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation rec {
   pname = "fribidi";
-  version = "1.0.12";
+  version = "1.0.13";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   # NOTE: Only URL tarball has "Have pre-generated man pages: true", which works-around upstream usage of some rare ancient `c2man` fossil application.
   src = fetchurl {
     url = "https://github.com/fribidi/fribidi/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-DNIz+X/IxnuzrCfOhEDe9dP/rPUWdluRwsxlRJgpNJU=";
+    sha256 = "sha256-f6FsgMgb1iL3sZjTE1baE5zDGKY/x3YSF69BMJA/VKI=";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   pname = "fribidi";
   version = "1.0.12";
 
-  outputs = [ "out" "devdoc" ];
+  outputs = [ "out" "dev" "devdoc" ];
 
   # NOTE: Only URL tarball has "Have pre-generated man pages: true", which works-around upstream usage of some rare ancient `c2man` fossil application.
   src = fetchurl {


### PR DESCRIPTION
Fixes:
* CVE-2022-25308
* CVE-2022-25309
* CVE-2022-25310
