### PR TITLE
amazon-image: do not reimport pkgs

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -74,9 +74,8 @@ in {
       '';
 
     zfsBuilder = import ../../../lib/make-multi-disk-zfs-image.nix {
-      inherit lib config configFile;
+      inherit lib pkgs config configFile;
       inherit (cfg) contents format name;
-      pkgs = import ../../../.. { inherit (pkgs) system; }; # ensure we use the regular qemu-kvm package
 
       includeChannel = true;
 
@@ -123,10 +122,9 @@ in {
     };
 
     extBuilder = import ../../../lib/make-disk-image.nix {
-      inherit lib config configFile;
+      inherit lib pkgs config configFile;
 
       inherit (cfg) contents format name;
-      pkgs = import ../../../.. { inherit (pkgs) system; }; # ensure we use the regular qemu-kvm package
 
       fsType = "ext4";
       partitionTableType = if config.ec2.efi then "efi"


### PR DESCRIPTION
The duplicate import of pkgs did not forward nixpkgs options.