### PR TITLE
nixos/grafana: allow @chown syscalls when using unix sockets

### DIFF
--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -792,7 +792,10 @@ in {
         SystemCallArchitectures = "native";
         # Upstream grafana is not setting SystemCallFilter for compatibility
         # reasons, see https://github.com/grafana/grafana/pull/40176
-        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ] ++ lib.optional (cfg.protocol == "socket") [ "@chown" ];
         UMask = "0027";
       };
       preStart = ''


### PR DESCRIPTION
Grafana will unconditionally call chown on the socket after creating it, even if the configuration does not ask for a different socket gid.