### PR TITLE
Revert "nix-prefetch-git: Fix inconsistency with fetchgit regarding deepClone"

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -105,10 +105,6 @@ for arg; do
     fi
 done
 
-if test -n $deepClone; then
-    leaveDotGit=true
-fi
-
 if test -z "$url"; then
     usage
 fi


### PR DESCRIPTION
This reverts commit 1dfaad73ed98254c1c0522156fe45b115e0a8eb4.