### PR TITLE
Add clickhouse_jdbc, liquibase_clickhouse, and link to liquibase script

### DIFF
--- a/nixos/modules/services/databases/clickhouse.nix
+++ b/nixos/modules/services/databases/clickhouse.nix
@@ -22,6 +22,15 @@ with lib;
         '';
       };
 
+      usersXml = mkOption {
+        type = types.path;
+        default = "${cfg.package}/etc/clickhouse-server/users.xml";
+        description = lib.mdDoc ''
+          ClickHouse server users.xml override for
+          declaring user access permissions and privileges
+        '';
+      };
+
     };
 
   };
@@ -64,7 +73,7 @@ with lib;
       };
 
       "clickhouse-server/users.xml" = {
-        source = "${cfg.package}/etc/clickhouse-server/users.xml";
+        source = cfg.usersXml;
       };
     };
 

--- a/pkgs/development/java-modules/clickhouse_jdbc/default.nix
+++ b/pkgs/development/java-modules/clickhouse_jdbc/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchMavenArtifact }:
+
+stdenv.mkDerivation rec {
+  pname = "clickhouse-jdbc";
+  version = "0.6.0";
+
+  src = fetchMavenArtifact {
+    artifactId = "clickhouse-jdbc";
+    groupId = "com.clickhouse";
+    classifier = "all";
+    sha256 = "sha256-WlNvgX1jwBIMsJOltVkXrvUPHv2hlfg6CaT5gSiFbZw=";
+    inherit version;
+  };
+
+  ## Use the `-all` jar to avoid having to fetch clickhouse-client (and perhaps other jars) as transitive dependencies.
+  installPhase = ''
+    runHook preInstall
+    install -m444 -D $src/share/java/clickhouse-jdbc-${version}.jar $out/share/java/clickhouse-jdbc-all.jar
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ClickHouse/clickhouse-java/tree/main/clickhouse-jdbc";
+    description = "JDBC driver for ClickHouse allowing Java programs to connect to a ClickHouse database";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/java-modules/liquibase_clickhouse/default.nix
+++ b/pkgs/development/java-modules/liquibase_clickhouse/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchMavenArtifact }:
+
+stdenv.mkDerivation rec {
+  pname = "liquibase-clickhouse";
+  version = "0.7.3-awake";
+
+  src = fetchMavenArtifact {
+    artifactId = "liquibase-clickhouse";
+    groupId = "com.mediarithmics";
+    sha256 = "sha256-nTLOPAwKgbzmIAutMhHVpC8d6F0UvcLDa94mB2MJwAo=";
+    classifier = "shaded";
+    repos = [
+      "http://jenkins.mv.awakenetworks.net:9081/content/repositories/thirdpartypatched/"
+    ];
+    inherit version;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -m444 -D $src/share/java/*liquibase-clickhouse-${version}.jar $out/share/java/liquibase-clickhouse.jar
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/MEDIARITHMICS/liquibase-clickhouse";
+    description = "ClickHouse driver for Liquibase";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -8,12 +8,16 @@
 , mysql_jdbc
 , postgresqlSupport ? true
 , postgresql_jdbc
+, clickhouseSupport ? true
+, liquibase_clickhouse
+, clickhouse_jdbc
 }:
 
 let
   extraJars =
     lib.optional mysqlSupport mysql_jdbc
-    ++ lib.optional postgresqlSupport postgresql_jdbc;
+    ++ lib.optional postgresqlSupport postgresql_jdbc
+    ++ lib.optionals clickhouseSupport [liquibase_clickhouse clickhouse_jdbc];
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22673,6 +22673,10 @@ with pkgs;
 
   clickhouse-backup = callPackage ../development/tools/database/clickhouse-backup { };
 
+  clickhouse_jdbc = callPackage ../development/java-modules/clickhouse_jdbc { };
+
+  liquibase_clickhouse = callPackage ../development/java-modules/liquibase_clickhouse { };
+
   codeowners = callPackage ../development/tools/codeowners { };
 
   couchdb3 = callPackage ../servers/http/couchdb/3.nix {


### PR DESCRIPTION
Introduces clickhouse-jdbc, liquibase-clickhouse Java modules.
Uses liquibase-clickhouse local version to avoid use of obsolete clickhouse-jdbc
Make clickhouse users.xml configurable
Use `shaded` uberjar for liquibase-clickhouse to avoid managing transitive dependencies.