### PR TITLE
terraform-cloud-agent: initialize derivation & NixOS service module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -480,6 +480,7 @@
   ./services/hardware/vdr.nix
   ./services/home-automation/home-assistant.nix
   ./services/home-automation/zigbee2mqtt.nix
+  ./services/infrastructure/terraform-cloud-agent/default.nix
   ./services/logging/SystemdJournal2Gelf.nix
   ./services/logging/awstats.nix
   ./services/logging/filebeat.nix

--- a/nixos/modules/services/infrastructure/terraform-cloud-agent/default.nix
+++ b/nixos/modules/services/infrastructure/terraform-cloud-agent/default.nix
@@ -1,0 +1,146 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.terraform-cloud-agent;
+in
+{
+  options.services.terraform-cloud-agent = {
+    enable = lib.mkEnableOption "terraform-cloud-agent";
+
+    tokenPath = lib.mkOption {
+      type = lib.types.str;
+      default = "$CONFIGURATION_DIRECTORY/token";
+      description = lib.mdDoc "Path to the Terraform Cloud token this agent should use.";
+      example = "/etc/terraform-cloud-agent/token";
+    };
+
+    data-dir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = lib.mdDoc "Directory tfc-agent should store its state.";
+    };
+
+    cache-dir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = lib.mdDoc "Directory tfc-agent should store its cache.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "tfc-agent";
+      description = lib.mdDoc "User account under which terraform-cloud-agent runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "tfc-agent";
+      description = lib.mdDoc "Group account under which terraform-cloud-agent runs.";
+    };
+
+    flags = lib.mkOption {
+      description = lib.mdDoc "Set of NixOS options that are used as flags to the tfc-agent executable.";
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf lib.types.str;
+
+        options = {
+          name = lib.mkOption {
+            type = lib.types.str;
+            description = lib.mdDoc "Name of the tfc-agent process.";
+            example = "silly-rhino-balderdash";
+          };
+
+          log-level = lib.mkOption {
+            type = lib.types.nullOr (lib.types.enum [ "trace" "debug" "info" "warn" "error" ]);
+            default = null;
+            description = lib.mdDoc "Level at which log messages should be emitted.";
+            example = "warn";
+          };
+
+          address = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = lib.mdDoc "HTTP or HTTPS address of the Terraform Cloud API.";
+            example = "https://app.terraform.io";
+          };
+
+          accept = lib.mkOption {
+            type = lib.types.commas;
+            default = "plan,apply,policy,assessment";
+            description = lib.mdDoc "Optional string of comma-separated job types that this agent may run. Acceptable job types are 'plan', 'apply', 'policy', and 'assessment'. Do not put whitespace in between entries.";
+            example = "plan,apply";
+          };
+
+          auto-update = lib.mkOption {
+            type = lib.types.str;
+            readOnly = true;
+            default = "disabled";
+            description = lib.mdDoc "Controls automatic core updates behavior. Not acceptable in NixOS, so disabled.";
+          };
+        };
+      };
+    };
+  };
+
+  config = {
+    systemd.services.terraform-cloud-agent = lib.mkIf cfg.enable {
+      description = "Agent that executes plans from Terraform Cloud";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+
+      script = ''
+        export TFC_AGENT_TOKEN=$(${pkgs.coreutils}/bin/cat ${cfg.tokenPath})
+        export TFC_AGENT_DATA_DIR=$STATE_DIRECTORY
+        export TFC_AGENT_CACHE_DIR=$CACHE_DIRECTORY
+    
+        ${lib.getExe pkgs.terraform-cloud-agent} ${lib.cli.toGNUCommandLineShell { mkOptionName = k: "-${k}"; } cfg.flags}
+      '';
+
+      serviceConfig = {
+        StateDirectory = "terraform-cloud-agent";
+        CacheDirectory = "terraform-cloud-agent";
+
+        ConfigurationDirectory = "terraform-cloud-agent";
+
+        # User and group
+        User = cfg.user;
+        Group = cfg.group;
+
+        # Below shamelessly cribbed from the nginx module: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-servers/nginx/default.nix
+
+        # Security
+        NoNewPrivileges = true;
+
+        # Sandboxing (sorted by occurrence in https://www.freedesktop.org/software/systemd/man/systemd.exec.html)
+        ProtectSystem = "strict";
+        ProtectHome = lib.mkDefault true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        PrivateMounts = true;
+      };
+    };
+
+    users.users = lib.mkIf (cfg.user == "tfc-agent") {
+      "tfc-agent" = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "tfc-agent") {
+      "tfc-agent" = { };
+    };
+  };
+}

--- a/pkgs/tools/infrastructure/terraform-cloud-agent/default.nix
+++ b/pkgs/tools/infrastructure/terraform-cloud-agent/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  pname = "tfc-agent";
+  version = "1.13.0";
+  src = fetchzip {
+    url = "https://releases.hashicorp.com/tfc-agent/${version}/tfc-agent_${version}_linux_amd64.zip";
+    sha256 = "sha256-juhTmxf5+6pGare598HKu8ha5Mxs5RaGWQima/jpf2o=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install tfc-agent* $out/bin/
+  '';
+
+  meta = {
+    description = "Polling Terraform Cloud Agent";
+    license = lib.licenses.unfree;
+    homepage = "https://developer.hashicorp.com/terraform/cloud-docs/agents";
+    sourceProvenance = [
+      lib.sourceTypes.binaryNativeCode
+    ];
+
+    platforms = [
+      "x86_64-linux"
+    ];
+
+    mainProgram = "tfc-agent";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36201,6 +36201,8 @@ with pkgs;
 
   terraform-landscape = callPackage ../applications/networking/cluster/terraform-landscape {};
 
+  terraform-cloud-agent = callPackage ../tools/infrastructure/terraform-cloud-agent {};
+
   terragrunt = callPackage ../applications/networking/cluster/terragrunt {};
 
   terranix = callPackage ../applications/networking/cluster/terranix {};


### PR DESCRIPTION
Redo of #181. NB review comments from that PR are addressed on this branch (I linked the commits in each comment on the original PR).

This change adds a derivation for the [`terraform-cloud-agent`][1] executable and a NixOS module that defines a systemd service for running that agent.

[1]: https://developer.hashicorp.com/terraform/cloud-docs/agents.