### PR TITLE
nixos/postgresql: increase systemd timeout during upgrade

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -55,10 +55,20 @@ let
         exit 0
       fi
 
+      while true; do
+        echo "Extending systemd timeout to 2 minutes from now while upgrade is running"
+        ${lib.getExe' pkgs.systemd "systemd-notify"} --status="Running major version upgrade" EXTEND_TIMEOUT_USEC=120000000
+        sleep 60
+      done &
+      timer_pid="$!"
+
       pushd "${cfg.dataDir}"
-      ${postgresql}/bin/pg_upgrade ${lib.cli.toGNUCommandLineShell {} args} ${lib.escapeShellArgs cfg.upgrade.extraArgs}
-      popd
-      touch "${cfg.dataDir}/.post_upgrade"
+      ${postgresql}/bin/pg_upgrade ${lib.cli.toGNUCommandLineShell { } args} ${lib.escapeShellArgs cfg.upgrade.extraArgs}
+      touch .post_upgrade
+
+      # Restore timeout consumed by upgrade
+      kill $timer_pid
+      ${lib.getExe' pkgs.systemd "systemd-notify"} --status="" EXTEND_TIMEOUT_USEC=120000000
     '';
   };
 
@@ -668,7 +678,14 @@ in
           '' + optionalString cfg.upgrade.enable ''
             if test -e "${cfg.dataDir}/.post_upgrade"; then
               ${optionalString cfg.upgrade.runAnalyze ''
-                vacuumdb --port=${toString cfg.port} --all --analyze-in-stages
+                while true; do
+                  echo "Extending systemd timeout to 2 minutes from now while post-upgarde vacuum/analyze is running"
+                  ${lib.getExe' pkgs.systemd "systemd-notify"} --status="Running post-upgrade vacuum/analyze" EXTEND_TIMEOUT_USEC=120000000
+                  sleep 60
+                done &
+                timer_pid="$!"
+                vacuumdb --port=${toString cfg.settings.port} --all --analyze-in-stages
+                kill $timer_pid
               ''}
               rm -f "${cfg.dataDir}/.post_upgrade"
             fi
@@ -710,6 +727,7 @@ in
             Type = if versionAtLeast cfg.package.version "9.6"
                    then "notify"
                    else "simple";
+            NotifyAccess = "all";
 
             # Shut down Postgres using SIGINT ("Fast Shutdown mode").  See
             # http://www.postgresql.org/docs/current/static/server-shutdown.html


### PR DESCRIPTION
There is a timeout of 2 minutes for start and stop of postgresql. However, upgrades can take much longer.

I've discovered that we can extend timeout using systemd-notify only during active upgrade instead of changing the limit globally.
See:
- https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#EXTEND_TIMEOUT_USEC=%E2%80%A6
- https://www.freedesktop.org/software/systemd/man/latest/systemd-notify.html