### PR TITLE
Backport nixos/nginx: add systemd-tmpfiles exclusion of temporary directories

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1340,6 +1340,11 @@ in
       nginx.gid = config.ids.gids.nginx;
     };
 
+    # do not delete the default temp directories created upon nginx startup
+    systemd.tmpfiles.rules = [
+      "X /tmp/systemd-private-%b-nginx.service-*/tmp/nginx_*"
+    ];
+
     services.logrotate.settings.nginx = mapAttrs (_: mkDefault) {
       files = "/var/log/nginx/*.log";
       frequency = "weekly";


### PR DESCRIPTION
Backport of: https://github.com/NixOS/nixpkgs/pull/257828 (specifically: https://github.com/NixOS/nixpkgs/commit/ea1eb4ee0fa44dd4cd37e8ece2634370d1c2b0d2.patch).