### PR TITLE
nixos/sssd: assert that nscd is enabled

### DIFF
--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -77,6 +77,10 @@ in {
   };
   config = mkMerge [
     (mkIf cfg.enable {
+      assertions = [{
+        assertion = nscd.enable;
+        message = "sssd currently relies on nscd";
+      }];
       # For `sssctl` to work.
       environment.etc."sssd/sssd.conf".source = settingsFile;
       environment.etc."sssd/conf.d".source = "${dataDir}/conf.d";


### PR DESCRIPTION
Since the configuration assumes nscd.conf exists and nss is configured