### PR TITLE
python3Packages.black: 23.11.0 -> 24.2.0 

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "black";
-  version = "24.1.1";
+  version = "24.2.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-SLV2Dcv+XPl/1PuiOUZoHzqBUUxquKRbUNpnrI+8bHs";
+    hash = "sha256-vOTyXCfDQ15NrOSBW8sgCLh+Fn479O5HzNxc6QbrSJQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -5,7 +5,6 @@
 , pythonOlder
 , pytestCheckHook
 , aiohttp
-, aiohttp-cors
 , click
 , colorama
 , hatch-fancy-pypi-readme
@@ -19,7 +18,6 @@
 , platformdirs
 , tokenize-rt
 , tomli
-, typed-ast
 , typing-extensions
 , uvloop
 }:
@@ -77,6 +75,10 @@ buildPythonPackage rec {
     pytestCheckHook
     parameterized
   ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+
+  pytestFlagsArray = [
+    "-W" "ignore::DeprecationWarning"
+  ];
 
   preCheck = ''
     export PATH="$PATH:$out/bin"

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "black";
-  version = "23.11.0";
+  version = "24.1.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-TGiFWCX/Qy0ZcimEb5cbxNZmbOkEkuWwIBO8rKTZqwU=";
+    hash = "sha256-SLV2Dcv+XPl/1PuiOUZoHzqBUUxquKRbUNpnrI+8bHs";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -20,13 +20,13 @@
 
 buildPythonPackage rec {
   pname = "hatchling";
-  version = "1.18.0";
+  version = "1.19.0";
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-UOmcMRDOCvw/e9ut/xxxwXdY5HZzHCdgeUDPpmhkico=";
+    hash = "sha256-CFfBdcdODSKcwmeTqudTr85FT+Du2hv4MX+3NypAXYI=";
   };
 
   # listed in backend/pyproject.toml

--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -20,13 +20,13 @@
 
 buildPythonPackage rec {
   pname = "hatchling";
-  version = "1.19.0";
+  version = "1.21.0";
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-CFfBdcdODSKcwmeTqudTr85FT+Du2hv4MX+3NypAXYI=";
+    hash = "sha256-XAhncjV6UHI7gl/V2lJ4rH42l833eX0HVBpskLb/dUw=";
   };
 
   # listed in backend/pyproject.toml


### PR DESCRIPTION
This is to upgrade it ahead of nixpkgs bump so the diff on the bump branch is managable.
These will be dropped during the next bump, since they are already applied there