### PR TITLE
Revert "drop! nixos/postgresql: fix `extraPlugins` type"

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -40,7 +40,7 @@ let
       # works.
       base = if cfg.enableJIT then cfg.package.withJIT else cfg.package.withoutJIT;
     in
-    if cfg.extraPlugins == null
+    if cfg.extraPlugins == []
       then base
       else base.withPackages cfg.extraPlugins;
 
@@ -417,8 +417,8 @@ in
       };
 
       extraPlugins = mkOption {
-        type = with types; nullOr (coercedTo (listOf path) (path: _ignorePg: path) (functionTo (listOf path)));
-        default = null;
+        type = with types; coercedTo (listOf path) (path: _ignorePg: path) (functionTo (listOf path));
+        default = _: [];
         example = literalExpression "ps: with ps; [ postgis pg_repack ]";
         description = ''
           List of PostgreSQL plugins.


### PR DESCRIPTION
This reverts commit e25632036e707f695d2d5473038f3d5cb3c00c57.