### PR TITLE
Cleanup old overrides

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+<!--
+    Please note: This blank issue template is meant for extraordinary issues
+    that do not fit the templates. Unless you know your issue is relevant to
+    Nixpkgs and requires the free-form blank issue, please use the issue
+    templates instead.
+-->

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,143 @@
+name: "Bug report (package)"
+description: "Create a generic bug report against a package."
+title: "PACKAGENAME: BUG TITLE"
+labels: ["0.kind: bug"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Welcome to Nixpkgs. Please replace the **`PACKAGENAME: BUG TITLE`** template above with the correct package name (As seen in the [NixOS Package Search](https://search.nixos.org/packages)) and a short title summarising what the bug entails.
+
+        > [!TIP]
+        > For instance, if you were filing a bug against the [`hello`](https://search.nixos.org/packages?channel=unstable&from=0&size=1&buckets=%7B%22package_attr_set%22%3A%5B%22No%20package%20set%22%5D%2C%22package_license_set%22%3A%5B%22GNU%20General%20Public%20License%20v3.0%20or%20later%22%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=hello) package about it failing to launch on ARM Linux, your title would be as follows:
+        > `hello: fails to launch on aarch64-linux`
+
+        ---
+  - type: "dropdown"
+    id: "version"
+    attributes:
+      label: "Nixpkgs version"
+      description: |
+        What version of Nixpkgs are you using?
+
+        > [!IMPORTANT]
+        > If you are using an older version, please update to the latest stable version and check if the issue persists before continuing this bug report.
+      options:
+        - "Please select a version."
+        - "- Unstable (25.05)"
+        - "- Stable (24.11)"
+        - "- Previous Stable (24.05)"
+      default: 0
+    validations:
+      required: true
+  - type: "textarea"
+    id: "description"
+    attributes:
+      label: "Describe the bug"
+      description: "Please include a clear and concise description of what the issue is."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "how-to-reproduce"
+    attributes:
+      label: "Steps to reproduce"
+      description: "Please include a step-by-step guide for reproducing this issue. Consider writing in concise, numbered bullet points to ensure that Nixpkgs developers can retrace your steps."
+    validations:
+      required: true
+  - type: "input"
+    id: "expected-behaviour"
+    attributes:
+      label: "Expected behaviour"
+      description: "Please write a concise description of what was supposed to happen."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "screenshots"
+    attributes:
+      label: "Screenshots"
+      description: |
+        If applicable, add screenshots to help explain your problem.
+        If you need help uploading images to GitHub, please review the [relevant documentation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#uploading-assets).
+    validations:
+      required: false
+  - type: "textarea"
+    id: "logs"
+    attributes:
+      label: "Relevant log output"
+      description: |
+        If applicable, copy and paste any relevant log output.
+        This will be automatically formatted into code, so no need for backticks.
+      render: "console"
+    validations:
+      required: false
+  - type: "textarea"
+    id: "additional-context"
+    attributes:
+      label: "Additional context"
+      description: "Add any other context about the problem here."
+    validations:
+      required: false
+  - type: "textarea"
+    id: "metadata"
+    attributes:
+      label: "System metadata"
+      description: "Please run `nix-shell -p nix-info --run \"nix-info -m\"` on a terminal and paste the output of that command here."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      description: |
+        This bug tracker is for actionable issues that are not the result of user error. If you need help using your system and are unsure if this is a bug with Nixpkgs, please consider asking for help on the [NixOS Discourse](https://discourse.nixos.org/) or the [NixOS Matrix Space](https://matrix.to/#/#community:nixos.org) before opening an issue.
+      options:
+        - label: "I assert that this is a bug and not a support request."
+          required: true
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%220.kind%3A+bug%22+-label%3A%226.topic%3A+darwin%22+-label%3A%226.topic%3A+nixos%22). "
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve Nixpkgs!
+
+        ---
+  - type: "textarea"
+    id: "prioritisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
@@ -1,0 +1,157 @@
+name: "Bug report (macOS)"
+description: "Create a bug report against a package where the issue only occurs on macOS."
+title: "PACKAGENAME: BUG TITLE"
+labels: ["0.kind: bug", "6.topic: darwin"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Welcome to Nixpkgs. Please replace the **`PACKAGENAME: BUG TITLE`** template above with the correct package name (As seen in the [NixOS Package Search](https://search.nixos.org/packages)) and a short title summarising what the bug entails.
+
+        > [!TIP]
+        > For instance, if you were filing a bug against the [`hello`](https://search.nixos.org/packages?channel=unstable&from=0&size=1&buckets=%7B%22package_attr_set%22%3A%5B%22No%20package%20set%22%5D%2C%22package_license_set%22%3A%5B%22GNU%20General%20Public%20License%20v3.0%20or%20later%22%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=hello) package about it failing to launch on Apple Silicon, your title would be as follows:
+        > `hello: fails to launch on aarch64-darwin`
+
+        ---
+  - type: "dropdown"
+    id: "version"
+    attributes:
+      label: "Nixpkgs version"
+      description: |
+        What version of Nixpkgs are you using?
+
+        > [!IMPORTANT]
+        > If you are using an older version, please update to the latest stable version and check if the issue persists before continuing this bug report.
+      options:
+        - "Please select a version."
+        - "- Unstable (25.05)"
+        - "- Stable (24.11)"
+        - "- Previous Stable (24.05)"
+      default: 0
+    validations:
+      required: true
+  - type: "textarea"
+    id: "description"
+    attributes:
+      label: "Describe the bug"
+      description: "Please include a clear and concise description of what the issue is."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "how-to-reproduce"
+    attributes:
+      label: "Steps to reproduce"
+      description: "Please include a step-by-step guide for reproducing this issue. Consider writing in concise, numbered bullet points to ensure that Nixpkgs developers can retrace your steps."
+    validations:
+      required: true
+  - type: "input"
+    id: "expected-behaviour"
+    attributes:
+      label: "Expected behaviour"
+      description: "Please write a concise description of what was supposed to happen."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "screenshots"
+    attributes:
+      label: "Screenshots"
+      description: |
+        If applicable, add screenshots to help explain your problem.
+        If you need help uploading images to GitHub, please review the [relevant documentation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#uploading-assets).
+    validations:
+      required: false
+  - type: "textarea"
+    id: "logs"
+    attributes:
+      label: "Relevant log output"
+      description: |
+        If applicable, copy and paste any relevant log output.
+        This will be automatically formatted into code, so no need for backticks.
+      render: "console"
+    validations:
+      required: false
+  - type: "textarea"
+    id: "additional-context"
+    attributes:
+      label: "Additional context"
+      description: "Add any other context about the problem here."
+    validations:
+      required: false
+  - type: "textarea"
+    id: "metadata"
+    attributes:
+      label: "System metadata"
+      description: "Please run `nix-shell -p nix-info --run \"nix-info -m\"` on a terminal and paste the output of that command here."
+    validations:
+      required: true
+  - type: "dropdown"
+    id: "nix-darwin"
+    attributes:
+      label: "Are you using nix-darwin?"
+      description: |
+        [`nix-darwin`](https://github.com/LnL7/nix-darwin) is a set of NixOS-like modules for macOS systems. Depending on your issue, this information may be relevant.
+      options:
+        - "Yes, I am using nix-darwin."
+        - "No, I am not using nix-darwin."
+      default: 1
+    validations:
+      required: true
+  - type: "textarea"
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
+
+        If this issue is related to the Darwin packaging architecture as a whole, or is related to the core Darwin frameworks, consider mentioning the `@NixOS/darwin-core` team.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      description: |
+        This bug tracker is for actionable issues that are not the result of user error. If you need help using your system and are unsure if this is a bug with Nixpkgs/NixOS, please consider asking for help on the [NixOS Discourse](https://discourse.nixos.org/) or the [NixOS Matrix Space](https://matrix.to/#/#community:nixos.org) before opening an issue.
+      options:
+        - label: "I assert that this is a bug and not a support request."
+          required: true
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%220.kind%3A+bug%22+label%3A%226.topic%3A+darwin%22). "
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve Nixpkgs!
+
+        ---
+  - type: "textarea"
+    id: "prioritisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
+++ b/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
@@ -1,0 +1,147 @@
+name: "Bug report (NixOS module)"
+description: "Create a bug report against a NixOS Module."
+title: "nixos/MODULENAME: BUG TITLE"
+labels: ["0.kind: bug", "6.topic: nixos"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Welcome to Nixpkgs. Please replace the **`nixos/MODULENAME: BUG TITLE`** template above with the correct module name (As seen in the [NixOS Option Search](https://search.nixos.org/options)) and a short title summarising what the bug entails.
+
+        > [!TIP]
+        > For instance, if you were filing a bug against the [`systemd-boot`](https://search.nixos.org/options?channel=unstable&show=boot.loader.systemd-boot.enable&from=0&size=1) module about it failing to install [`memtest86`](https://search.nixos.org/options?channel=unstable&show=boot.loader.systemd-boot.memtest86.enable&from=0&size=1), your title would be as follows:
+        > `nixos/systemd-boot: fails to install memtest86`
+
+        ---
+  - type: "dropdown"
+    id: "version"
+    attributes:
+      label: "Nixpkgs version"
+      description: |
+        What version of Nixpkgs are you using?
+
+        > [!IMPORTANT]
+        > If you are using an older version, please [update to the latest stable version](https://nixos.org/download) and check if the issue persists before continuing this bug report.
+      options:
+        - "Please select a version."
+        - "- Unstable (25.05)"
+        - "- Stable (24.11)"
+        - "- Previous Stable (24.05)"
+      default: 0
+    validations:
+      required: true
+  - type: "textarea"
+    id: "description"
+    attributes:
+      label: "Describe the bug"
+      description: "Please include a clear and concise description of what the issue is."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "how-to-reproduce"
+    attributes:
+      label: "Steps to reproduce"
+      description: "Please include a step-by-step guide for reproducing this issue. Consider writing in concise, numbered bullet points to ensure that Nixpkgs developers can retrace your steps."
+    validations:
+      required: true
+  - type: "input"
+    id: "expected-behaviour"
+    attributes:
+      label: "Expected behaviour"
+      description: "Please write a concise description of what was supposed to happen."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "screenshots"
+    attributes:
+      label: "Screenshots"
+      description: |
+        If applicable, add screenshots to help explain your problem.
+        If you need help uploading images to GitHub, please review the [relevant documentation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#uploading-assets).
+    validations:
+      required: false
+  - type: "textarea"
+    id: "logs"
+    attributes:
+      label: "Relevant log output"
+      description: |
+        If applicable, copy and paste any relevant log output.
+        This will be automatically formatted into code, so no need for backticks.
+      render: "console"
+    validations:
+      required: false
+  - type: "textarea"
+    id: "additional-context"
+    attributes:
+      label: "Additional context"
+      description: "Add any other context about the problem here."
+    validations:
+      required: false
+  - type: "textarea"
+    id: "metadata"
+    attributes:
+      label: "System metadata"
+      description: "Please run `nix-shell -p nix-info --run \"nix-info -m\"` on a terminal and paste the output of that command here."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the `meta.maintainers` list of the offending module. This is done by prefixing the person's username with an '@' character. You can quickly go to the source code of a module by searching for it on the [NixOS Option Search](https://search.nixos.org/options) and clicking the "Declared in..." button.
+
+        Please note that the maintainer attribute name does not always match the maintainer's GitHub username. If that occurs, try looking in [`maintainers/maintainer-list.nix`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix) for the maintainer attribute name, and checking if the maintainer has a listed GitHub username.
+
+        If in doubt, check `git blame` for whoever last touched the module, or check the associated package's maintainers. Please add the mentions above the `---` characters.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      description: |
+        This bug tracker is for actionable issues that are not the result of user error. If you need help using your system and are unsure if this is a bug with Nixpkgs, please consider asking for help on the [NixOS Discourse](https://discourse.nixos.org/) or the [NixOS Matrix Space](https://matrix.to/#/#community:nixos.org) before opening an issue.
+      options:
+        - label: "I assert that this is a bug and not a support request."
+          required: true
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%220.kind%3A+bug%22+label%3A%226.topic%3A+nixos%22). "
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve Nixpkgs!
+
+        ---
+  - type: "textarea"
+    id: "prioritisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/04_build_failure.yml
+++ b/.github/ISSUE_TEMPLATE/04_build_failure.yml
@@ -1,0 +1,150 @@
+name: "Build failure"
+description: "Report a package that is failing to build."
+title: "Build failure: PACKAGENAME"
+labels: ["0.kind: build failure"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Welcome to Nixpkgs. Please replace the **`Build failure: PACKAGENAME`** template above with the correct package name (As seen in the [NixOS Package Search](https://search.nixos.org/packages)).
+
+        > [!TIP]
+        > For instance, if you were filing a build failure against the [`hello`](https://search.nixos.org/packages?channel=unstable&from=0&size=1&buckets=%7B%22package_attr_set%22%3A%5B%22No%20package%20set%22%5D%2C%22package_license_set%22%3A%5B%22GNU%20General%20Public%20License%20v3.0%20or%20later%22%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=hello) package, your title would be as follows:
+        > `Build failure: hello`
+
+        ---
+  - type: "dropdown"
+    id: "version"
+    attributes:
+      label: "Nixpkgs version"
+      description: |
+        In what version of Nixpkgs did the build failure occur?
+
+        > [!IMPORTANT]
+        > If you are using an older version, please update to the latest stable version and check if the build failure persists before continuing this report.
+        > If you are purposefully trying to build an ancient version of a package in an older Nixpkgs, please coordinate with the [NixOS Archivists](https://matrix.to/#/#archivists:nixos.org).
+      options:
+        - "Please select a version."
+        - "- Unstable (25.05)"
+        - "- Stable (24.11)"
+        - "- Previous Stable (24.05)"
+      default: 0
+    validations:
+      required: true
+  - type: "textarea"
+    id: "how-to-reproduce"
+    attributes:
+      label: "Steps to reproduce"
+      description: "Please include a step-by-step guide for reproducing this build failure. Consider writing in concise, numbered bullet points to ensure that Nixpkgs developers can retrace your steps."
+    validations:
+      required: true
+  - type: "dropdown"
+    id: "hydra"
+    attributes:
+      label: "Can Hydra reproduce this build failure?"
+      description: |
+        Can [Hydra](https://hydra.nixos.org), Nixpkgs' Continuous Integration system, reproduce this build failure?
+        Please use the search function in the header bar to locate the last build job for the package in question.
+        - If there's a <img src="https://raw.githubusercontent.com/NixOS/hydra/refs/heads/master/src/root/static/images/emojione-red-x-274c.svg" width="20px" align="top" alt="Red X"> icon near the package entry, say '**Yes, Hydra can reproduce this build failure.**'
+        - If there's a <img src="https://raw.githubusercontent.com/NixOS/hydra/refs/heads/master/src/root/static/images/emojione-gray-x-2716.svg" width="20px" align="top" alt="Dark Gray X"> icon near the package entry, then the build failure occurs with another package, and you need to track the original failing package by going down the chain of 'Cached failures' until you reach the final package in the failing dependency chain. Once you locate the failing package, re-write this report against that package and say '**Yes, Hydra can reproduce this build failure.**'
+        - If there's a <img src="https://raw.githubusercontent.com/NixOS/hydra/refs/heads/master/src/root/static/images/emojione-check-2714.svg" width="20px" align="top" alt="Green Check Mark"> icon near the package entry, then it most likely means it's a local issue with your system. (Maybe you ran out of space?)
+          You can still open a build failure report, but please say '**No, Hydra cannot reproduce this build failure.**' below.
+        - If there's a <img src="https://raw.githubusercontent.com/NixOS/hydra/refs/heads/master/src/root/static/images/emojione-question-2754.svg" width="20px" align="top" alt="Gray Question Mark"> icon near the package entry, say '**Hydra is currently rebuilding this package.**'
+        - If there's a <img src="https://raw.githubusercontent.com/NixOS/hydra/refs/heads/master/src/root/static/images/emojione-stopsign-1f6d1.svg" width="20px" align="top" alt="Red Stop Sign"> icon near the package entry, then the build job was stopped manually. If this occurs, please coordinate with the [Infrastructure Team](https://matrix.to/#/#infra:nixos.org), and say '**The last build job was manually cancelled.**'
+      options:
+        - "Please select the Hydra Status."
+        - "Yes, Hydra can reproduce this build failure."
+        - "No, Hydra cannot reproduce this build failure."
+        - "Hydra is currently rebuilding this package."
+        - "The last build job was manually cancelled."
+      default: 0
+    validations:
+      required: true
+  - type: "input"
+    id: "hydra-logs"
+    attributes:
+      label: "Link to Hydra build job"
+      description: "If you answered 'yes' in the question above, please copy-and-paste the link to the failing Hydra job here."
+    validations:
+      required: false
+  - type: "textarea"
+    id: "logs"
+    attributes:
+      label: "Relevant log output"
+      description: |
+        Please copy and paste the logs from the failed build.
+        This will be automatically formatted into code, so no need for backticks.
+      render: "console"
+    validations:
+      required: true
+  - type: "textarea"
+    id: "additional-context"
+    attributes:
+      label: "Additional context"
+      description: "Add any other context about the problem here."
+    validations:
+      required: false
+  - type: "textarea"
+    id: "metadata"
+    attributes:
+      label: "System metadata"
+      description: "Please run `nix-shell -p nix-info --run \"nix-info -m\"` on a terminal and paste the output of that command here."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      description: |
+        This bug tracker is for actionable issues that are not the result of user error. If you need help using your system and are unsure if this is a bug with Nixpkgs, please consider asking for help on the [NixOS Discourse](https://discourse.nixos.org/) or the [NixOS Matrix Space](https://matrix.to/#/#community:nixos.org) before opening an issue.
+      options:
+        - label: "I assert that this is a bug and not a support request."
+          required: true
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%220.kind%3A+build+failure%22). "
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve Nixpkgs!
+
+        ---
+  - type: "textarea"
+    id: "prioritisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/05_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/05_update_request.yml
@@ -1,0 +1,121 @@
+name: "Request: package update"
+description: "Create an update request for an existing, but outdated package."
+title: "Update Request: PACKAGENAME OLDVERSION → NEWVERSION"
+labels: ["0.kind: enhancement", "9.needs: package (update)"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Welcome to Nixpkgs. Please replace the **`Update Request: PACKAGENAME OLDVERSION → NEWVERSION`** template above with the correct package name (As seen in the [NixOS Package Search](https://search.nixos.org/packages)), the current version of the package, and the latest version of the package.
+
+        > [!TIP]
+        > For instance, if you were filing a request against the out of date `hello` package, where the current version in Nixpkgs is 1.0.0, but the latest version upstream is 1.0.1, your title would be as follows:
+        > `Update Request: hello 1.0.0 → 1.0.1`
+
+        > [!NOTE]
+        > If you are filing an update request to change a package's source to a fork, please file a new package request instead. Even if the original upstream is outdated, the fork should be considered a new package.
+
+        ---
+  - type: "dropdown"
+    id: "version"
+    attributes:
+      label: "Nixpkgs version"
+      description: |
+        What version of Nixpkgs are you using?
+
+        > [!IMPORTANT]
+        > If you are using an older or stable version, please update to the latest **unstable** version and check if the package is still out of date.
+        > If the package has been updated in unstable, but you believe the update should be backported to the stable release of Nixpkgs, please file the '**Request: backport to stable**' form instead.
+      options:
+        - "Please select a version."
+        - "- Unstable (25.05)"
+        - "- Stable (24.11)"
+        - "- Previous Stable (24.05)"
+      default: 0
+    validations:
+      required: true
+  - type: "input"
+    id: "name"
+    attributes:
+      label: "Package name"
+      description: "Please indicate the name of the package."
+    validations:
+      required: true
+  - type: "input"
+    id: "upstream-version"
+    attributes:
+      label: "Upstream version"
+      description: "Please indicate the latest version of the package."
+    validations:
+      required: true
+  - type: "input"
+    id: "nixpkgs-version"
+    attributes:
+      label: "Nixpkgs version"
+      description: |
+        Please indicate the current version number in Nixpkgs' **unstable** channel. You can check this by setting the [NixOS Package Search](https://search.nixos.org/packages?channel=unstable) channel to 'unstable' and searching for the package.
+        If you meant to request an upgrade in the stable channel, please file the '**Request: backport to stable**' form instead.
+    validations:
+      required: true
+  - type: "input"
+    id: "changelog"
+    attributes:
+      label: "Changelog"
+      description: "If applicable, please link the upstream changelog for the latest version."
+    validations:
+      required: false
+  - type: "textarea"
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      options:
+        - label: "I assert that this package update does not yet exist in an [open pull request](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+is%3Apr+label%3A%228.has%3A+package+%28update%29%22) or in [Nixpkgs Unstable](https://search.nixos.org/packages?channel=unstable)."
+          required: true
+        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%229.needs%3A+package+%28update%29%22)."
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve Nixpkgs!
+
+        ---
+  - type: "textarea"
+    id: "prioritisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/06_module_request.yml
+++ b/.github/ISSUE_TEMPLATE/06_module_request.yml
@@ -1,0 +1,101 @@
+name: "Request: NixOS module"
+description: "Create a new NixOS Module request for an existing package."
+title: "Module Request: nixos/MODULENAME"
+labels: ["0.kind: enhancement", "6.topic: nixos", "9.needs: module (new)"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Welcome to Nixpkgs. Please replace the **`Module Request: nixos/MODULENAME`** template above with the correct module name (As seen in the [NixOS Option Search](https://search.nixos.org/options)).
+
+        > [!TIP]
+        > For instance, if you were filing a request against the missing `hello` module, your title would be as follows:
+        > `Module Request: nixos/hello`
+
+        ---
+  - type: "dropdown"
+    id: "version"
+    attributes:
+      label: "Nixpkgs version"
+      description: |
+        What version of Nixpkgs are you using?
+
+        > [!IMPORTANT]
+        > If you are using an older or stable version, please update to the latest **unstable** version and check if the module still does not exist before continuing this request.
+      options:
+        - "Please select a version."
+        - "- Unstable (25.05)"
+        - "- Stable (24.11)"
+        - "- Previous Stable (24.05)"
+      default: 0
+    validations:
+      required: true
+  - type: "textarea"
+    id: "description"
+    attributes:
+      label: "Describe the proposed module"
+      description: "Please include a clear and concise description of what the module should accomplish."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "additional-context"
+    attributes:
+      label: "Additional context"
+      description: "Add any other context about the proposed module here."
+    validations:
+      required: false
+  - type: "textarea"
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      options:
+        - label: "I assert that this module does not yet exist in an [open pull request](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+is%3Apr+label%3A%228.has%3A+module+%28new%29%22) or in [NixOS Unstable](https://search.nixos.org/options?channel=unstable)."
+          required: true
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%229.needs%3A+module+%28new%29%22). "
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve NixOS!
+
+        ---
+  - type: "textarea"
+    id: "prioritisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/07_backport_request.yml
+++ b/.github/ISSUE_TEMPLATE/07_backport_request.yml
@@ -1,0 +1,103 @@
+name: "Request: backport to stable"
+description: "Create a backport request for a package that is up-to-date in the unstable channel, but outdated in the stable channel."
+title: "Backport to Stable: PACKAGENAME OLDVERSION → NEWVERSION"
+labels: ["0.kind: enhancement", "9.needs: port to stable"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        > [!CAUTION]
+        > **Before you begin:** Be advised that backports are subject to the [release suitability guidelines](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
+        > Stable releases of Nixpkgs do not receive breaking changes, which include major package updates that have incompatible API changes and break backwards compatibility. In the [Semantic Versioning standard](https://semver.org/), this is the first version number. (1.X.X)
+        > Generally, only minor package updates, such as security patches, bug fixes and feature additions (but not removals!) will be considered for backporting. Please read the rules above carefully before filing this backport request.
+
+        Welcome to Nixpkgs. Please replace the **`Backport to Stable: PACKAGENAME OLDVERSION → NEWVERSION`** template above with the correct package name (As seen in the [NixOS Package Search](https://search.nixos.org/packages)), the current version of the package in Nixpkgs Stable and the current version of the package in Nixpkgs Unstable.
+
+        > [!TIP]
+        > For instance, if you were filing a request against the out of date `hello` package, where the current version in Nixpkgs Unstable is 1.0.1, but the current version in Nixpkgs Stable is 1.0.0, your title would be as follows:
+        > `Backport to Stable: hello 1.0.0 → 1.0.1`
+
+        ---
+  - type: "input"
+    id: "name"
+    attributes:
+      label: "Package name"
+      description: "Please indicate the name of the package."
+    validations:
+      required: true
+  - type: "input"
+    id: "unstable-version"
+    attributes:
+      label: "Version in unstable"
+      description: "Please indicate the current version of the package in the unstable channel."
+    validations:
+      required: true
+  - type: "input"
+    id: "stable-version"
+    attributes:
+      label: "Version in stable"
+      description: "Please indicate the current version of the package in the stable channel."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "reasoning"
+    attributes:
+      label: "Reasoning for backport"
+      description: "Please briefly explain why this backport fits the [release suitability guidelines](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases) and why you think this update should be backported."
+    validations:
+      required: false
+  - type: "textarea"
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      options:
+        - label: "I assert that this backport does not yet exist in an [open pull request](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+in%3Atitle+backport)."
+          required: true
+        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+label%3A%229.needs%3A+port+to+stable%22+)."
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve Nixpkgs!
+
+        ---
+  - type: "textarea"
+    id: "prioritisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/08_documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/08_documentation_request.yml
@@ -1,0 +1,87 @@
+name: "Request: documentation"
+description: "Report missing or incorrect documentation in the NixOS or Nixpkgs manuals."
+title: "Missing Documentation: PACKAGENAME"
+labels: ["0.kind: enhancement", "9.needs: documentation"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Welcome to Nixpkgs. Please replace the **`Missing Documentation: PACKAGENAME`** template above with the correct package name (As seen in the [NixOS Package Search](https://search.nixos.org/packages)) or module name (As seen in the [NixOS Option Search](https://search.nixos.org/options)).
+
+        > [!TIP]
+        > For instance, if you were filing an issue against the [`hello`](https://search.nixos.org/packages?channel=unstable&from=0&size=1&buckets=%7B%22package_attr_set%22%3A%5B%22No%20package%20set%22%5D%2C%22package_license_set%22%3A%5B%22GNU%20General%20Public%20License%20v3.0%20or%20later%22%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=hello) package about it not having any NixOS-specific documentation, your title would be as follows:
+        > `Missing Documentation: hello`
+
+        ---
+  - type: "textarea"
+    id: "description"
+    attributes:
+      label: "Describe the problem"
+      description: "Please include a clear and concise description of what the issue is."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "proposal"
+    attributes:
+      label: "Proposed solution"
+      description: |
+        If possible, please draft a tentative documentation chapter to resolve this issue.
+        Your proposal should be written in CommonMark Markdown, optionally enhanced with [Nix-specific extensions](https://github.com/NixOS/nixpkgs/tree/master/doc#syntax).
+      render: "markdown"
+    validations:
+      required: false
+  - type: "textarea"
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      options:
+        - label: "I assert that this request is not already implemented in the latest [NixOS](https://nixos.org/manual/nixos/unstable/) or [Nixpkgs](https://nixos.org/manual/nixpkgs/unstable/) manuals."
+          required: true
+        - label: "I assert that this is not a [duplicate of an existing documentation issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+label%3A%229.needs%3A+documentation%22)."
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve Nixpkgs!
+
+        ---
+  - type: "textarea"
+    id: "priorisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/09_unreproducible_package.yml
+++ b/.github/ISSUE_TEMPLATE/09_unreproducible_package.yml
@@ -1,0 +1,158 @@
+name: "Unreproducible Package"
+description: "Report a package that does not produce a bit-by-bit reproducible result each time it is built."
+title: "Unreproducible Package: PACKAGENAME"
+labels: ["0.kind: enhancement", "6.topic: reproducible builds"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Welcome to Nixpkgs. Please replace the **`Unreproducible Package: PACKAGENAME`** template above with the correct package name (As seen in the [NixOS Package Search](https://search.nixos.org/packages)).
+
+        > [!NOTE]
+        > This form is for reporting unreproducible packages. For more information, see the [Reproducible Builds Status](https://reproducible.nixos.org/) page.
+        > To report a package that fails to build entirely, please use the "Build Failure" form instead.
+
+        ---
+  - type: "input"
+    id: "version"
+    attributes:
+      label: "Nixpkgs Revision"
+      description: "In which commit of Nixpkgs is this package displaying unreproducibility?"
+  - type: "textarea"
+    id: "introduction"
+    attributes:
+      label: "Introduction"
+      description: |
+        This is a generic introduction to build reproducibility.
+        Please replace **PACKAGENAME** below with the canonical package name of the package, as you have done for the title above.
+      value: |
+        Building **PACKAGENAME** multiple times does not yield bit-by-bit identical
+        results, complicating the detection of Continuous Integration (CI) breaches. For
+        more information on this issue, visit [reproducible-builds.org](https://reproducible-builds.org/).
+
+        Fixing bit-by-bit reproducibility also has additional advantages, such as
+        avoiding hard-to-reproduce bugs, making content-addressed storage more effective
+        and reducing rebuilds in such systems.
+    validations:
+      required: true
+  - type: "textarea"
+    id: "how-to-reproduce"
+    attributes:
+      label: "Steps to reproduce"
+      description: |
+        This is a step-by-step instruction set meant for maintainers to debug the package that is failing to reproduce. You should also follow it to gather the `diffoscope` logs that will be needed below.
+        Please replace **PACKAGENAME** below with the canonical package name of the package, as you have done for the introduction and the title above.
+      value: |
+        ### 1. Build the package
+
+        This step will build the package. Specific arguments are passed to the command
+        to keep the build artifacts so we can compare them in case of differences.
+
+        Execute the following command:
+
+        ```
+        nix-build '<nixpkgs>' -A PACKAGENAME && nix-build '<nixpkgs>' -A PACKAGENAME --check --keep-failed
+        ```
+
+        Or using the new command line style:
+
+        ```
+        nix build nixpkgs#PACKAGENAME && nix build nixpkgs#PACKAGENAME --rebuild --keep-failed
+        ```
+
+        ### 2. Compare the build artifacts
+
+        If the previous command completes successfully, no differences were found and
+        there's nothing to do, builds are reproducible.
+        If it terminates with the error message `error: derivation '<X>' may not be
+        deterministic: output '<Y>' differs from '<Z>'`, use `diffoscope` to investigate
+        the discrepancies between the two build outputs. You may need to add the
+        `--exclude-directory-metadata recursive` option to ignore files and directories
+        metadata (*e.g. timestamp*) differences.
+
+        ```
+        nix run nixpkgs#diffoscopeMinimal -- --exclude-directory-metadata recursive <Y> <Z>
+        ```
+
+        ### 3. Examine the build log
+
+        To examine the build log, use:
+
+        ```
+        nix-store --read-log $(nix-instantiate '<nixpkgs>' -A PACKAGENAME)
+        ```
+
+        Or with the new command line style:
+
+        ```
+        nix log $(nix path-info --derivation nixpkgs#PACKAGENAME)
+        ```
+    validations:
+      required: true
+  - type: "textarea"
+    id: "logs"
+    attributes:
+      label: "Diffoscope log"
+      description: |
+        Please copy and paste the relevant `diffoscope` log output, gathered from the steps above.
+        This will be automatically formatted into a monospaced text block, so no need for backticks.
+      render: "console"
+  - type: "textarea"
+    id: "additional-context"
+    attributes:
+      label: "Additional context"
+      description: "Add any other context about the problem here."
+    validations:
+      required: false
+    id: "maintainers"
+    attributes:
+      label: "Notify maintainers"
+      description: |
+        Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
+      value: |
+
+
+        ---
+
+        **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)
+    validations:
+      required: false
+  - type: "checkboxes"
+    id: "sanity-check"
+    attributes:
+      label: "I assert that this issue is relevant for Nixpkgs"
+      options:
+        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%226.topic%3A+reproducible+builds%22)."
+          required: true
+        - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
+          required: true
+  - type: "markdown"
+    attributes:
+      value: |
+        # Thank you for helping improve Nixpkgs!
+
+        ---
+  - type: "textarea"
+    id: "prioritisation"
+    attributes:
+      label: "Is this issue important to you?"
+      description: |
+        **Please do not modify this text area!**
+
+        This template helps Nixpkgs developers know which issues should be prioritised by allowing users to vote with a :+1: reaction.
+        This is not a guarantee that highly-requested issues will be fixed first, but it helps us to figure out what's important to users. Please react on other users' issues if you find them important.
+      value: |
+        Add a :+1: [reaction] to [issues you find important].
+
+        [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+        [issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+
+<!--
+^ Please summarise the changes you have done and explain why they are necessary here ^
+
+For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
+For new packages please briefly describe the package or provide a link to its homepage.
+-->
+
+## Things done
+
+<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
+
+- Built on platform(s)
+  - [ ] x86_64-linux
+  - [ ] aarch64-linux
+  - [ ] x86_64-darwin
+  - [ ] aarch64-darwin
+- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
+  - [ ] `sandbox = relaxed`
+  - [ ] `sandbox = true`
+- [ ] Tested, as applicable:
+  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
+  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
+  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
+  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
+- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
+- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
+- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
+  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
+  - [ ] (Module updates) Added a release notes entry if the change is significant
+  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
+- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
+
+<!--
+To help with the large amounts of pull requests, we would appreciate your
+reviews of other pull requests, especially simple package updates. Just leave a
+comment describing what you have tested in the relevant package/service.
+Reviewing helps to reduce the average time-to-merge for everyone.
+Thanks a lot if you do!
+
+List of open PRs: https://github.com/NixOS/nixpkgs/pulls
+Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
+-->
+
+---
+
+Add a :+1: [reaction] to [pull requests you find important].
+
+[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/STALE-BOT.md
+++ b/.github/STALE-BOT.md
@@ -1,0 +1,36 @@
+# Stale bot information
+
+- Thanks for your contribution!
+- Our stale bot will never close an issue or PR.
+- To remove the stale label, just leave a new comment.
+- _How to find the right people to ping?_ &rarr; [`git blame`](https://git-scm.com/docs/git-blame) to the rescue! (or GitHub's history and blame buttons.)
+- You can always ask for help on [our Discourse Forum](https://discourse.nixos.org/), [our Matrix room](https://matrix.to/#/#nix:nixos.org), or on the [#nixos IRC channel](https://web.libera.chat/#nixos).
+
+## Suggestions for PRs
+
+1. GitHub sometimes doesn't notify people who commented / reviewed a PR previously, when you (force) push commits. If you have addressed the reviews you can [officially ask for a review](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review) from those who commented to you or anyone else.
+2. If it is unfinished but you plan to finish it, please mark it as a draft.
+3. If you don't expect to work on it any time soon, closing it with a short comment may encourage someone else to pick up your work.
+4. To get things rolling again, rebase the PR against the target branch and address valid comments.
+5. If you need a review to move forward, ask in [the Discourse thread for PRs that need help](https://discourse.nixos.org/t/prs-in-distress/3604).
+6. If all you need is a merge, check the git history to find and [request reviews](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review) from people who usually merge related contributions.
+
+## Suggestions for issues
+
+1. If it is resolved (either for you personally, or in general), please consider closing it.
+2. If this might still be an issue, but you are not interested in promoting its resolution, please consider closing it while encouraging others to take over and reopen an issue if they care enough.
+3. If you still have interest in resolving it, try to ping somebody who you believe might have an interest in the topic. Consider discussing the problem in [our Discourse Forum](https://discourse.nixos.org/).
+4. As with all open source projects, your best option is to submit a Pull Request that addresses this issue. We :heart: this attitude!
+
+**Memorandum on closing issues**
+
+Don't be afraid to close an issue that holds valuable information. Closed issues stay in the system for people to search, read, cross-reference, or even reopen--nothing is lost! Closing obsolete issues is an important way to help maintainers focus their time and effort.
+
+## Useful GitHub search queries
+
+- [Open PRs with any stale-bot interaction](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+commenter%3Aapp%2Fstale+)
+- [Open PRs with any stale-bot interaction and `2.status: stale`](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+commenter%3Aapp%2Fstale+label%3A%222.status%3A+stale%22)
+- [Open PRs with any stale-bot interaction and NOT `2.status: stale`](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+commenter%3Aapp%2Fstale+-label%3A%222.status%3A+stale%22+)
+- [Open Issues with any stale-bot interaction](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+commenter%3Aapp%2Fstale+)
+- [Open Issues with any stale-bot interaction and `2.status: stale`](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+commenter%3Aapp%2Fstale+label%3A%222.status%3A+stale%22+)
+- [Open Issues with any stale-bot interaction and NOT `2.status: stale`](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+commenter%3Aapp%2Fstale+-label%3A%222.status%3A+stale%22+)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -1,0 +1,28 @@
+# This file is used by .github/workflows/labels.yml
+# This version uses `sync-labels: false`, meaning that a non-match will NOT remove the label
+
+"backport release-24.11":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/workflows/*
+        - ci/**/*.*
+
+"6.topic: policy discussion":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/**/*
+        - CONTRIBUTING.md
+        - pkgs/README.md
+        - nixos/README.md
+        - maintainers/README.md
+        - lib/README.md
+        - doc/README.md
+
+"8.has: documentation":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/**/*
+        - nixos/doc/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,581 @@
+# This file is used by .github/workflows/labels.yml
+# This version uses `sync-labels: true`, meaning that a non-match will remove the label
+
+# NOTE: bsd, darwin and cross-compilation labels are handled by ofborg
+"6.topic: agda":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/agda.section.md
+        - nixos/tests/agda.nix
+        - pkgs/build-support/agda/**/*
+        - pkgs/development/libraries/agda/**/*
+        - pkgs/top-level/agda-packages.nix
+
+"6.topic: cinnamon":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/x11/desktop-managers/cinnamon.nix
+        - nixos/tests/cinnamon.nix
+        - nixos/tests/cinnamon-wayland.nix
+        - pkgs/by-name/ci/cinnamon-*/**/*
+        - pkgs/by-name/cj/cjs/**/*
+        - pkgs/by-name/mu/muffin/**/*
+        - pkgs/by-name/ne/nemo/**/*
+        - pkgs/by-name/ne/nemo-*/**/*
+
+"6.topic: continuous integration":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/**/*
+        - ci/**/*
+
+"6.topic: coq":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/applications/science/logic/coq/**/*
+        - pkgs/development/coq-modules/**/*
+        - pkgs/top-level/coq-packages.nix
+
+"6.topic: crystal":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/development/compilers/crystal/**/*
+
+"6.topic: cuda":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/development/cuda-modules/**/*
+        - pkgs/top-level/cuda-packages.nix
+
+"6.topic: deepin":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/desktops/deepin/**/*
+        - pkgs/desktops/deepin/**/*
+
+"6.topic: docker tools":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/applications/virtualization/docker/**/*
+
+"6.topic: dotnet":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/dotnet.section.md
+        - maintainers/scripts/update-dotnet-lockfiles.nix
+        - pkgs/build-support/dotnet/**/*
+        - pkgs/development/compilers/dotnet/**/*
+        - pkgs/test/dotnet/**/*
+        - pkgs/top-level/dotnet-packages.nix
+
+"6.topic: emacs":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/editors/emacs.nix
+        - nixos/modules/services/editors/emacs.xml
+        - nixos/tests/emacs-daemon.nix
+        - pkgs/applications/editors/emacs/build-support/**/*
+        - pkgs/applications/editors/emacs/elisp-packages/**/*
+        - pkgs/applications/editors/emacs/**/*
+        - pkgs/top-level/emacs-packages.nix
+
+"6.topic: Enlightenment DE":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/x11/desktop-managers/enlightenment.nix
+        - pkgs/desktops/enlightenment/**/*
+        - pkgs/development/python-modules/python-efl/*
+
+"6.topic: erlang":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/beam.section.md
+        - pkgs/development/beam-modules/**/*
+        - pkgs/development/interpreters/elixir/**/*
+        - pkgs/development/interpreters/erlang/**/*
+        - pkgs/development/tools/build-managers/rebar/**/*
+        - pkgs/development/tools/build-managers/rebar3/**/*
+        - pkgs/development/tools/erlang/**/*
+        - pkgs/top-level/beam-packages.nix
+
+"6.topic: fetch":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/build-support/fetch*/**/*
+
+"6.topic: flakes":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - '**/flake.nix'
+        - lib/systems/flake-systems.nix
+        - nixos/modules/config/nix-flakes.nix
+
+"6.topic: flutter":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/build-support/flutter/*.nix
+        - pkgs/development/compilers/flutter/**/*.nix
+
+"6.topic: games":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/games/**/*
+
+"6.topic: GNOME":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/gnome.section.md
+        - nixos/modules/services/desktops/gnome/**/*
+        - nixos/modules/services/x11/desktop-managers/gnome.nix
+        - nixos/tests/gnome-xorg.nix
+        - nixos/tests/gnome.nix
+        - pkgs/desktops/gnome/**/*
+
+"6.topic: golang":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/go.section.md
+        - pkgs/build-support/go/**/*
+        - pkgs/development/compilers/go/**/*
+
+"6.topic: hardware":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/hardware/**/*
+
+"6.topic: haskell":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/haskell.section.md
+        - maintainers/scripts/haskell/**/*
+        - pkgs/development/compilers/ghc/**/*
+        - pkgs/development/haskell-modules/**/*
+        - pkgs/development/tools/haskell/**/*
+        - pkgs/test/haskell/**/*
+        - pkgs/top-level/haskell-packages.nix
+        - pkgs/top-level/release-haskell.nix
+
+"6.topic: java":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        # Distributions
+        - pkgs/development/compilers/adoptopenjdk-icedtea-web/**/*
+        - pkgs/development/compilers/corretto/**/*
+        - pkgs/development/compilers/graalvm/**/*
+        - pkgs/development/compilers/openjdk/**/*
+        - pkgs/by-name/op/openjfx/**/*
+        - pkgs/development/compilers/semeru-bin/**/*
+        - pkgs/development/compilers/temurin-bin/**/*
+        - pkgs/development/compilers/zulu/**/*
+        # Documentation
+        - doc/languages-frameworks/java.section.md
+        # Gradle
+        - doc/languages-frameworks/gradle.section.md
+        - pkgs/development/tools/build-managers/gradle/**/*
+        - pkgs/by-name/gr/gradle-completion/**/*
+        # Maven
+        - pkgs/by-name/ma/maven/**/*
+        - doc/languages-frameworks/maven.section.md
+        # Ant
+        - pkgs/by-name/an/ant/**/*
+        # javaPackages attrset
+        - pkgs/development/java-modules/**/*
+        - pkgs/top-level/java-packages.nix
+        # Maintainer tooling
+        - pkgs/by-name/ni/nixpkgs-openjdk-updater/**/*
+        # Misc
+        - nixos/modules/programs/java.nix
+
+"6.topic: jitsi":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/networking/jitsi-videobridge.nix
+        - nixos/modules/services/web-apps/jitsi-meet.nix
+        - pkgs/servers/web-apps/jitsi-meet/**/*
+        - pkgs/servers/jitsi-videobridge/**/*
+        - pkgs/applications/networking/instant-messengers/jitsi/**/*
+
+"6.topic: julia":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/julia.section.md
+        - pkgs/development/compilers/julia/**/*
+        - pkgs/development/julia-modules/**/*
+
+"6.topic: jupyter":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/development/python-modules/jupyter*/**/*
+        - pkgs/development/python-modules/mkdocs-jupyter/*
+        - nixos/modules/services/development/jupyter/**/*
+        - pkgs/applications/editors/jupyter-kernels/**/*
+        - pkgs/applications/editors/jupyter/**/*
+
+"6.topic: k3s":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/cluster/k3s/**/*
+        - nixos/tests/k3s/**/*
+        - pkgs/applications/networking/cluster/k3s/**/*
+
+"6.topic: kernel":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/build-support/kernel/**/*
+        - pkgs/os-specific/linux/kernel/**/*
+
+"6.topic: lib":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - lib/**
+
+"6.topic: llvm/clang":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/development/compilers/llvm/**/*
+
+"6.topic: lua":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/development/tools/misc/luarocks/*
+        - pkgs/development/interpreters/lua-5/**/*
+        - pkgs/development/interpreters/luajit/**/*
+        - pkgs/development/lua-modules/**/*
+        - pkgs/top-level/lua-packages.nix
+
+"6.topic: Lumina DE":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/x11/desktop-managers/lumina.nix
+        - pkgs/desktops/lumina/**/*
+
+"6.topic: LXQt":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/x11/desktop-managers/lxqt.nix
+        - pkgs/desktops/lxqt/**/*
+
+"6.topic: mate":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/x11/desktop-managers/mate.nix
+        - nixos/tests/mate.nix
+        - pkgs/desktops/mate/**/*
+
+"6.topic: module system":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - lib/modules.nix
+        - lib/types.nix
+        - lib/options.nix
+        - lib/tests/modules.sh
+        - lib/tests/modules/**
+
+"6.topic: musl":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/os-specific/linux/musl/**/*
+
+"6.topic: nixos":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/**/*
+        - pkgs/by-name/sw/switch-to-configuration-ng/**/*
+        - pkgs/by-name/ni/nixos-rebuild-ng/**/*
+        - pkgs/os-specific/linux/nixos-rebuild/**/*
+
+"6.topic: nixos-container":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/virtualisation/nixos-containers.nix
+        - pkgs/tools/virtualization/nixos-container/**/*
+
+"6.topic: nim":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/nim.section.md
+        - pkgs/build-support/build-nim-package.nix
+        - pkgs/build-support/build-nim-sbom.nix
+        - pkgs/by-name/ni/nim*
+        - pkgs/top-level/nim-overrides.nix
+
+"6.topic: nodejs":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/javascript.section.md
+        - pkgs/build-support/node/**/*
+        - pkgs/development/node-packages/**/*
+        - pkgs/development/tools/yarn/*
+        - pkgs/development/tools/yarn2nix-moretea/**/*
+        - pkgs/development/tools/pnpm/**/*
+        - pkgs/development/web/nodejs/*
+
+"6.topic: nvidia":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/hardware/video/nvidia.nix
+        - nixos/modules/services/hardware/nvidia-container-toolkit/**/*
+        - nixos/modules/services/hardware/nvidia-optimus.nix
+        - pkgs/os-specific/linux/nvidia-x11/**/*
+
+"6.topic: ocaml":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/ocaml.section.md
+        - pkgs/development/compilers/ocaml/**/*
+        - pkgs/development/compilers/reason/**/*
+        - pkgs/development/ocaml-modules/**/*
+        - pkgs/development/tools/ocaml/**/*
+        - pkgs/top-level/ocaml-packages.nix
+
+"6.topic: pantheon":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/desktops/pantheon/**/*
+        - nixos/modules/services/x11/desktop-managers/pantheon.nix
+        - nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
+        - nixos/tests/pantheon.nix
+        - pkgs/desktops/pantheon/**/*
+
+"6.topic: php":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/php.section.md
+        - nixos/tests/php/**/*
+        - pkgs/build-support/php/**/*
+        - pkgs/development/interpreters/php/**/*
+        - pkgs/development/php-packages/**/*
+        - pkgs/test/php/default.nix
+        - pkgs/top-level/php-packages.nix
+
+"6.topic: printing":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/printing/cupsd.nix
+        - pkgs/misc/cups/**/*
+
+"6.topic: python":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/python.section.md
+        - pkgs/development/interpreters/python/**/*
+        - pkgs/development/python-modules/**/*
+        - pkgs/top-level/python-packages.nix
+
+"6.topic: qt/kde":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/qt.section.md
+        - nixos/modules/services/x11/desktop-managers/plasma5.nix
+        - nixos/tests/plasma5.nix
+        - pkgs/applications/kde/**/*
+        - pkgs/desktops/plasma-5/**/*
+        - pkgs/development/libraries/kde-frameworks/**/*
+        - pkgs/development/libraries/qt-5/**/*
+
+"6.topic: R":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/applications/science/math/R/**/*
+        - pkgs/development/r-modules/**/*
+
+"6.topic: rocm":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/development/rocm-modules/**/*
+
+"6.topic: ruby":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/ruby.section.md
+        - pkgs/development/interpreters/ruby/**/*
+        - pkgs/development/ruby-modules/**/*
+        - pkgs/top-level/ruby-packages.nix
+
+"6.topic: rust":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/rust.section.md
+        - pkgs/build-support/rust/**/*
+        - pkgs/development/compilers/rust/**/*
+
+"6.topic: stdenv":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/stdenv/**/*
+
+"6.topic: steam":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/games/steam/**/*
+
+"6.topic: systemd":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/os-specific/linux/systemd/**/*
+        - nixos/modules/system/boot/systemd*/**/*
+
+"6.topic: tcl":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/tcl.section.md
+        - pkgs/development/interpreters/tcl/*
+        - pkgs/development/tcl-modules/**/*
+        - pkgs/top-level/tcl-packages.nix
+
+"6.topic: teams":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+          - maintainers/team-list.nix
+
+"6.topic: TeX":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/texlive.section.md
+        - pkgs/test/texlive/**
+        - pkgs/tools/typesetting/tex/**/*
+
+"6.topic: testing":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        # NOTE: Let's keep the scope limited to test frameworks that are
+        #       *developed in this repo*;
+        #       - not individual tests
+        #       - not packages for test frameworks
+        - pkgs/build-support/testers/**
+        - nixos/lib/testing/**
+        - nixos/lib/test-driver/**
+        - nixos/tests/nixos-test-driver/**
+        - nixos/lib/testing-python.nix      # legacy
+        - nixos/tests/make-test-python.nix  # legacy
+        # lib/debug.nix has a test framework (runTests) but it's not the main focus
+
+"6.topic: updaters":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/common-updater/**/*
+
+"6.topic: vim":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/vim.section.md
+        - pkgs/applications/editors/vim/**/*
+        - pkgs/applications/editors/vim/plugins/**/*
+        - nixos/modules/programs/neovim.nix
+        - pkgs/applications/editors/neovim/**/*
+
+"6.topic: vscode":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/applications/editors/vscode/**/*
+
+"6.topic: windows":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/os-specific/windows/**/*
+
+"6.topic: xen-project":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/virtualisation/xen*
+        - pkgs/by-name/xe/xen/*
+        - pkgs/by-name/qe/qemu_xen/*
+        - pkgs/by-name/xe/xen-guest-agent/*
+        - pkgs/by-name/xt/xtf/*
+        - pkgs/build-support/xen/*
+        - pkgs/development/ocaml-modules/xen*/*
+        - pkgs/development/ocaml-modules/vchan/*
+
+"6.topic: xfce":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/doc/manual/configuration/xfce.xml
+        - nixos/modules/services/x11/desktop-managers/xfce.nix
+        - nixos/tests/xfce.nix
+        - pkgs/desktops/xfce/**/*
+
+"6.topic: zig":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - pkgs/development/compilers/zig/**/*
+        - doc/hooks/zig.section.md
+
+"8.has: changelog":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/doc/manual/release-notes/**/*
+
+"8.has: module (update)":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/**/*
+"8.has: maintainer-list (update)":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - maintainers/maintainer-list.nix

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,9 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+daysUntilStale: 180
+daysUntilClose: false
+exemptLabels:
+  - "1.severity: security"
+  - "2.status: never-stale"
+staleLabel: "2.status: stale"
+markComment: false
+closeComment: false

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,20 @@
+# GitHub Actions Workflows
+
+Some architectural notes about key decisions and concepts in our workflows:
+
+- Instead of `pull_request` we use [`pull_request_target`](https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) for all PR-related workflows. This has the advantage that those workflows will run without prior approval for external contributors.
+
+- Running on `pull_request_target` also optionally provides us with a GH_TOKEN with elevated privileges (write access), which we need to do things like adding labels, requesting reviewers or pushing branches. **Note about security:** We need to be careful to limit the scope of elevated privileges as much as possible. Thus they should be lowered to the minimum with `permissions: {}` in every workflow by default.
+
+- By definition `pull_request_target` runs in the context of the **base** of the pull request. This means, that the workflow files to run will be taken from the base branch, not the PR, and actions/checkout will not checkout the PR, but the base branch, by default. To protect our secrets, we need to make sure to **never execute code** from the pull request and always evaluate or build nix code from the pull request with the **sandbox enabled**.
+
+- To test the pull request's contents, we checkout the "test merge commit". This is a temporary commit that GitHub creates automatically as "what would happen, if this PR was merged into the base branch now?". The checkout could be done via the virtual branch `refs/pull/<pr-number>/merge`, but doing so would cause failures when this virtual branch doesn't exist (anymore). This can happen when the PR has conflicts, in which case the virtual branch is not created, or when the PR is getting merged while workflows are still running, in which case the branch won't exist anymore at the time of checkout. Thus, we use the `get-merge-commit.yml` workflow to check whether the PR is mergeable and the test merge commit exists and only then run the relevant jobs.
+
+- Various workflows need to make comparisons against the base branch. In this case, we checkout the parent of the "test merge commit" for best results. Note, that this is not necessarily the same as the default commit that actions/checkout would use, which is also a commit from the base branch (see above), but might be older.
+
+## Terminology
+
+- **base commit**: The pull_request_target event's context commit, i.e. the base commit given by GitHub Actions. Same as `github.event.pull_request.base.sha`.
+- **head commit**: The HEAD commit in the pull request's branch. Same as `github.event.pull_request.head.sha`.
+- **merge commit**: The temporary "test merge commit" that GitHub Actions creates and updates for the pull request. Same as `refs/pull/${{ github.event.pull_request.number }}/merge`.
+- **target commit**: The base branch's parent of the "test merge commit" to compare against.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,43 @@
+# WARNING:
+# When extending this action, be aware that $GITHUB_TOKEN allows write access to
+# the GitHub repository. This means that it should not evaluate user input in a
+# way that allows code injection.
+
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions: {}
+
+jobs:
+  backport:
+    name: Backport Pull Request
+    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    runs-on: ubuntu-24.04
+    steps:
+      # Use a GitHub App to create the PR so that CI gets triggered
+      # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create backport PRs
+        uses: korthout/backport-action@436145e922f9561fc5ea157ff406f21af2d6b363 # v3.2.0
+        with:
+          # Config README: https://github.com/korthout/backport-action#backport-action
+          copy_labels_pattern: 'severity:\ssecurity'
+          github_token: ${{ steps.app-token.outputs.token }}
+          pull_description: |-
+            Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
+
+            * [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
+              * Even as a non-commiter, if you find that it is not acceptable, leave a comment.

--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -1,0 +1,28 @@
+name: "Check cherry-picks"
+
+on:
+  pull_request_target:
+    branches:
+      - 'release-**'
+      - 'staging-**'
+      - '!staging-next'
+
+permissions: {}
+
+jobs:
+  check:
+    name: cherry-pick-check
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == 'NixOS'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Check cherry-picks
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          ./maintainers/scripts/check-cherry-picks.sh "$BASE_SHA" "$HEAD_SHA"

--- a/.github/workflows/check-maintainers-sorted.yml
+++ b/.github/workflows/check-maintainers-sorted.yml
@@ -1,0 +1,28 @@
+name: "Check that maintainer list is sorted"
+
+on:
+  pull_request_target:
+    paths:
+      - 'maintainers/maintainer-list.nix'
+
+permissions: {}
+
+jobs:
+  nixos:
+    name: maintainer-list-check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          # Only these directories to perform the check
+          sparse-checkout: |
+            lib
+            maintainers
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Check that maintainer-list.nix is sorted
+        run: nix-instantiate --eval maintainers/scripts/check-maintainers-sorted.nix

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -1,0 +1,44 @@
+# NOTE: Formatting with the RFC-style nixfmt command is not yet stable.
+# See https://github.com/NixOS/rfcs/pull/166.
+
+name: Check that Nix files are formatted
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions: {}
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  nixos:
+    name: nixfmt-check
+    runs-on: ubuntu-24.04
+    needs: get-merge-commit
+    if: needs.get-merge-commit.outputs.mergedSha
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Check that Nix files are formatted
+        run: |
+          # Note that it's fine to run this on untrusted code because:
+          # - There's no secrets accessible here
+          # - The build is sandboxed
+          if ! nix-build ci -A fmt.check; then
+            echo "Some Nix files are not properly formatted"
+            echo "Please format them by going to the Nixpkgs root directory and running one of:"
+            echo "  nix-shell --run treefmt"
+            echo "  nix develop --command treefmt"
+            echo "  nix fmt"
+            echo "Make sure your branch is up to date with master; rebase if not."
+            echo "If you're having trouble, please ping @NixOS/nix-formatting"
+            exit 1
+          fi

--- a/.github/workflows/check-nixf-tidy.yml
+++ b/.github/workflows/check-nixf-tidy.yml
@@ -1,0 +1,132 @@
+name: Check changed Nix files with nixf-tidy (experimental)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions: {}
+
+jobs:
+  nixos:
+    name: exp-nixf-tidy-check
+    runs-on: ubuntu-24.04
+    if: "!contains(github.event.pull_request.title, '[skip treewide]')"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          # Fetches the merge commit and its parents
+          fetch-depth: 2
+
+      - name: Checking out target branch
+        run: |
+          target=$(mktemp -d)
+          targetRev=$(git rev-parse HEAD^1)
+          git worktree add "$target" "$targetRev"
+          echo "targetRev=$targetRev" >> "$GITHUB_ENV"
+          echo "target=$target" >> "$GITHUB_ENV"
+
+      - name: Get Nixpkgs revision for nixf
+        run: |
+          # pin to a commit from nixpkgs-unstable to avoid e.g. building nixf
+          # from staging
+          # This should not be a URL, because it would allow PRs to run arbitrary code in CI!
+          rev=$(jq -r .rev ci/pinned-nixpkgs.json)
+          echo "url=https://github.com/NixOS/nixpkgs/archive/$rev.tar.gz" >> "$GITHUB_ENV"
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+          nix_path: nixpkgs=${{ env.url }}
+
+      - name: Install nixf and jq
+        # provided jq is incompatible with our expression
+        run: "nix-env -f '<nixpkgs>' -iAP nixf jq"
+
+      - name: Check that Nix files pass nixf-tidy
+        run: |
+          # Filtering error messages we don't like
+          nixf_wrapper(){
+            nixf-tidy --variable-lookup < "$1" | jq -r '
+              [
+                "sema-escaping-with"
+              ]
+              as $ignored_errors|[.[]|select(.sname as $s|$ignored_errors|index($s)|not)]
+            '
+          }
+
+          failedFiles=()
+
+          # Don't report errors to file overview
+          # to avoid duplicates when editing title and description
+          if [[ "${{ github.event.action }}" == 'edited' ]] && [[ -z "${{ github.event.edited.changes.base }}" ]]; then
+            DONT_REPORT_ERROR=1
+          else
+            DONT_REPORT_ERROR=
+          fi
+          # TODO: Make this more parallel
+
+          # Loop through all Nix files touched by the PR
+          while readarray -d '' -n 2 entry && (( ${#entry[@]} != 0 )); do
+            type=${entry[0]}
+            file=${entry[1]}
+            case $type in
+              A*)
+                source=""
+                dest=$file
+                ;;
+              M*)
+                source=$file
+                dest=$file
+                ;;
+              C*|R*)
+                source=$file
+                read -r -d '' dest
+                ;;
+              *)
+                echo "Ignoring file $file with type $type"
+                continue
+            esac
+
+            if [[ -n "$source" ]] && [[ "$(nixf_wrapper ${{ env.target }}/"$source")" != '[]' ]] 2>/dev/null; then
+              echo "Ignoring file $file because it doesn't pass nixf-tidy in the target commit"
+              echo # insert blank line
+            else
+              nixf_report="$(nixf_wrapper "$dest")"
+              if [[ "$nixf_report" != '[]' ]]; then
+                echo "$dest doesn't pass nixf-tidy. Reported by nixf-tidy:"
+                errors=$(echo "$nixf_report" | jq -r --arg dest "$dest" '
+                  def getLCur: "line=" + (.line+1|tostring) + ",col=" + (.column|tostring);
+                  def getRCur: "endLine=" + (.line+1|tostring) + ",endColumn=" + (.column|tostring);
+                  def getRange: "file=\($dest)," + (.lCur|getLCur) + "," + (.rCur|getRCur);
+                  def getBody: . as $top|(.range|getRange) + ",title="+ .sname + "::" +
+                    (.message|sub("{}" ; ($top.args.[]|tostring)));
+                  def getNote: "\n::notice " + (.|getBody);
+                  def getMessage: "::error " + (.|getBody) + (if (.notes|length)>0 then
+                    ([.notes.[]|getNote]|add) else "" end);
+                  .[]|getMessage
+                ')
+                if [[ -z "$DONT_REPORT_ERROR" ]]; then
+                  echo "$errors"
+                else
+                  # just print in plain text
+                  echo "${errors/::/}"
+                  echo # add one empty line
+                fi
+                failedFiles+=("$dest")
+              fi
+            fi
+          done < <(git diff -z --name-status ${{ env.targetRev }} -- '*.nix')
+
+          if [[ -n "$DONT_REPORT_ERROR" ]]; then
+            echo "Edited the PR but didn't change the base branch, only the description/title."
+            echo "Not reporting errors again to avoid duplication."
+            echo # add one empty line
+          fi
+
+          if (( "${#failedFiles[@]}" > 0 )); then
+            echo "Some new/changed Nix files don't pass nixf-tidy."
+            echo "See ${{ github.event.pull_request.html_url }}/files for reported errors."
+            echo "If you believe this is a false positive, ping @Aleksanaa and @inclyc in this PR."
+            exit 1
+          fi

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -1,0 +1,33 @@
+name: "Check shell"
+
+on:
+  pull_request_target:
+    paths:
+      - 'shell.nix'
+      - 'ci/**'
+
+permissions: {}
+
+jobs:
+  shell-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            system: x86_64-linux
+          - runner: macos-14
+            system: aarch64-darwin
+
+    name: shell-check-${{ matrix.system }}
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+
+      - name: Build shell
+        run: nix-build shell.nix

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -1,0 +1,111 @@
+# This workflow depends on two GitHub Apps with the following permissions:
+# - For checking code owners:
+#   - Permissions:
+#     - Repository > Administration: read-only
+#     - Organization > Members: read-only
+#   - Install App on this repository, setting these variables:
+#     - OWNER_RO_APP_ID (variable)
+#     - OWNER_RO_APP_PRIVATE_KEY (secret)
+# - For requesting code owners:
+#   - Permissions:
+#     - Repository > Administration: read-only
+#     - Organization > Members: read-only
+#     - Repository > Pull Requests: read-write
+#   - Install App on this repository, setting these variables:
+#     - OWNER_APP_ID (variable)
+#     - OWNER_APP_PRIVATE_KEY (secret)
+#
+# This split is done because checking code owners requires handling untrusted PR input,
+# while requesting code owners requires PR write access, and those shouldn't be mixed.
+#
+# Note that the latter is also used for ./eval.yml requesting reviewers.
+
+name: Codeowners v2
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, synchronize, reopened, edited]
+
+permissions: {}
+
+env:
+  OWNERS_FILE: ci/OWNERS
+  # Don't do anything on draft PRs
+  DRY_MODE: ${{ github.event.pull_request.draft && '1' || '' }}
+
+jobs:
+  get-merge-commit:
+    if: github.repository_owner == 'NixOS'
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  # Check that code owners is valid
+  check:
+    name: Check
+    runs-on: ubuntu-24.04
+    needs: get-merge-commit
+    if: github.repository_owner == 'NixOS' && needs.get-merge-commit.outputs.mergedSha
+    steps:
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
+          name: nixpkgs-ci
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      # Important: Because we use pull_request_target, this checks out the base branch of the PR, not the PR itself.
+      # We later build and run code from the base branch with access to secrets,
+      # so it's important this is not the PRs code.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: base
+
+      - name: Build codeowners validator
+        run: nix-build base/ci -A codeownersValidator
+
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.OWNER_RO_APP_ID }}
+          private-key: ${{ secrets.OWNER_RO_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          path: pr
+
+      - name: Validate codeowners
+        run: result/bin/codeowners-validator
+        env:
+          OWNERS_FILE: pr/${{ env.OWNERS_FILE }}
+          GITHUB_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY_PATH: pr
+          OWNER_CHECKER_REPOSITORY: ${{ github.repository }}
+          # Set this to "notowned,avoid-shadowing" to check that all files are owned by somebody
+          EXPERIMENTAL_CHECKS: "avoid-shadowing"
+
+  # Request reviews from code owners
+  request:
+    name: Request
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == 'NixOS'
+    steps:
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+
+      # Important: Because we use pull_request_target, this checks out the base branch of the PR, not the PR head.
+      # This is intentional, because we need to request the review of owners as declared in the base branch.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.OWNER_APP_ID }}
+          private-key: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
+
+      - name: Build review request package
+        run: nix-build ci -A requestReviews
+
+      - name: Request reviews
+        run: result/bin/request-code-owner-reviews.sh ${{ github.repository }} ${{ github.event.number }} "$OWNERS_FILE"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/editorconfig-v2.yml
+++ b/.github/workflows/editorconfig-v2.yml
@@ -1,0 +1,47 @@
+name: "Checking EditorConfig v2"
+
+on:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  tests:
+    name: editorconfig-check
+    runs-on: ubuntu-24.04
+    needs: get-merge-commit
+    if: "needs.get-merge-commit.outputs.mergedSha && !contains(github.event.pull_request.title, '[skip treewide]')"
+    steps:
+      - name: Get list of changed files from PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/pulls/${{ github.event.number }}/files --paginate \
+            | jq '.[] | select(.status != "removed") | .filename' \
+            > "$HOME/changed_files"
+
+      - name: print list of changed files
+        run: |
+          cat "$HOME/changed_files"
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          # nixpkgs commit is pinned so that it doesn't break
+          # editorconfig-checker 2.4.0
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/c473cc8714710179df205b153f4e9fa007107ff9.tar.gz
+
+      - name: Checking EditorConfig
+        run: |
+          < "$HOME/changed_files" nix-shell -p editorconfig-checker --run 'xargs -r editorconfig-checker -disable-indent-size'
+
+      - if: ${{ failure() }}
+        run: |
+          echo "::error :: Hey! It looks like your changes don't follow our editorconfig settings. Read https://editorconfig.org/#download to configure your editor so you never see this error again."

--- a/.github/workflows/eval-lib-tests.yml
+++ b/.github/workflows/eval-lib-tests.yml
@@ -1,0 +1,31 @@
+name: "Building Nixpkgs lib-tests"
+
+on:
+  pull_request_target:
+    paths:
+      - 'lib/**'
+      - 'maintainers/**'
+
+permissions: {}
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  nixpkgs-lib-tests:
+    name: nixpkgs-lib-tests
+    runs-on: ubuntu-24.04
+    needs: get-merge-commit
+    if: needs.get-merge-commit.outputs.mergedSha
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Building Nixpkgs lib-tests
+        run: |
+          nix-build --arg pkgs "(import ./ci/. {}).pkgs" ./lib/tests/release.nix

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,342 @@
+name: Eval
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, synchronize, reopened]
+  push:
+    # Keep this synced with ci/request-reviews/dev-branches.txt
+    branches:
+      - master
+      - staging
+      - release-*
+      - staging-*
+      - haskell-updates
+      - python-updates
+
+permissions: {}
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  attrs:
+    name: Attributes
+    runs-on: ubuntu-24.04
+    needs: get-merge-commit
+    if: needs.get-merge-commit.outputs.mergedSha
+    outputs:
+      targetSha: ${{ steps.targetSha.outputs.targetSha }}
+      systems: ${{ steps.systems.outputs.systems }}
+    steps:
+      - name: Check out the PR at the test merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          fetch-depth: 2
+          path: nixpkgs
+
+      - name: Determine target commit
+        if: github.event_name == 'pull_request_target'
+        id: targetSha
+        run: |
+          targetSha=$(git -C nixpkgs rev-parse HEAD^1)
+          echo "targetSha=$targetSha" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Evaluate the list of all attributes and get the systems matrix
+        id: systems
+        run: |
+          nix-build nixpkgs/ci -A eval.attrpathsSuperset
+          echo "systems=$(<result/systems.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload the list of all attributes
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: paths
+          path: result/*
+
+  eval-aliases:
+    name: Eval nixpkgs with aliases enabled
+    runs-on: ubuntu-24.04
+    needs: [ get-merge-commit ]
+    steps:
+      - name: Check out the PR at the test merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          path: nixpkgs
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Ensure flake outputs on all systems still evaluate
+        run: nix --experimental-features 'nix-command flakes' flake check --all-systems --no-build ./nixpkgs
+
+      - name: Query nixpkgs with aliases enabled to check for basic syntax errors
+        run: |
+          time nix-env -I ./nixpkgs -f ./nixpkgs -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null
+
+  outpaths:
+    name: Outpaths
+    runs-on: ubuntu-24.04
+    needs: [ attrs, get-merge-commit ]
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ fromJSON(needs.attrs.outputs.systems) }}
+    steps:
+      - name: Enable swap
+        run: |
+          sudo fallocate -l 10G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+
+      - name: Download the list of all attributes
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: paths
+          path: paths
+
+      - name: Check out the PR at the test merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          path: nixpkgs
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Evaluate the ${{ matrix.system }} output paths for all derivation attributes
+        env:
+          MATRIX_SYSTEM: ${{ matrix.system }}
+        run: |
+          nix-build nixpkgs/ci -A eval.singleSystem \
+            --argstr evalSystem "$MATRIX_SYSTEM" \
+            --arg attrpathFile ./paths/paths.json \
+            --arg chunkSize 10000
+          # If it uses too much memory, slightly decrease chunkSize
+
+      - name: Upload the output paths and eval stats
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: intermediate-${{ matrix.system }}
+          path: result/*
+
+  process:
+    name: Process
+    runs-on: ubuntu-24.04
+    needs: [ outpaths, attrs, get-merge-commit ]
+    outputs:
+      targetRunId: ${{ steps.targetRunId.outputs.targetRunId }}
+    steps:
+      - name: Download output paths and eval stats for all systems
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: intermediate-*
+          path: intermediate
+
+      - name: Check out the PR at the test merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          fetch-depth: 2
+          path: nixpkgs
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Combine all output paths and eval stats
+        run: |
+          nix-build nixpkgs/ci -A eval.combine \
+            --arg resultsDir ./intermediate \
+            -o prResult
+
+      - name: Upload the combined results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: result
+          path: prResult/*
+
+      - name: Get target run id
+        if: needs.attrs.outputs.targetSha
+        id: targetRunId
+        run: |
+          # Get the latest eval.yml workflow run for the PR's target commit
+          if ! run=$(gh api --method GET /repos/"$REPOSITORY"/actions/workflows/eval.yml/runs \
+            -f head_sha="$TARGET_SHA" -f event=push \
+            --jq '.workflow_runs | sort_by(.run_started_at) | .[-1]') \
+            || [[ -z "$run" ]]; then
+            echo "Could not find an eval.yml workflow run for $TARGET_SHA, cannot make comparison"
+            exit 1
+          fi
+          echo "Comparing against $(jq .html_url <<< "$run")"
+          runId=$(jq .id <<< "$run")
+          conclusion=$(jq -r .conclusion <<< "$run")
+
+          while [[ "$conclusion" == null || "$conclusion" == "" ]]; do
+            echo "Workflow not done, waiting 10 seconds before checking again"
+            sleep 10
+            conclusion=$(gh api /repos/"$REPOSITORY"/actions/runs/"$runId" --jq '.conclusion')
+          done
+
+          if [[ "$conclusion" != "success" ]]; then
+            echo "Workflow was not successful (conclusion: $conclusion), cannot make comparison"
+            exit 1
+          fi
+
+          echo "targetRunId=$runId" >> "$GITHUB_OUTPUT"
+        env:
+          REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ needs.attrs.outputs.targetSha }}
+          GH_TOKEN: ${{ github.token }}
+
+      - uses: actions/download-artifact@v4
+        if: steps.targetRunId.outputs.targetRunId
+        with:
+          name: result
+          path: targetResult
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.targetRunId.outputs.targetRunId }}
+
+      - name: Compare against the target branch
+        if: steps.targetRunId.outputs.targetRunId
+        run: |
+          git -C nixpkgs worktree add ../target ${{ needs.attrs.outputs.targetSha }}
+          git -C nixpkgs diff --name-only ${{ needs.attrs.outputs.targetSha }} \
+            | jq --raw-input --slurp 'split("\n")[:-1]' > touched-files.json
+
+          # Use the target branch to get accurate maintainer info
+          nix-build target/ci -A eval.compare \
+            --arg beforeResultDir ./targetResult \
+            --arg afterResultDir ./prResult \
+            --arg touchedFilesJson ./touched-files.json \
+            -o comparison
+
+          cat comparison/step-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the combined results
+        if: steps.targetRunId.outputs.targetRunId
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: comparison
+          path: comparison/*
+
+  # Separate job to have a very tightly scoped PR write token
+  tag:
+    name: Tag
+    runs-on: ubuntu-24.04
+    needs: [ attrs, process ]
+    if: needs.process.outputs.targetRunId
+    permissions:
+      pull-requests: write
+      statuses: write
+    steps:
+      # See ./codeowners-v2.yml, reuse the same App because we need the same permissions
+      # Can't use the token received from permissions above, because it can't get enough permissions
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.OWNER_APP_ID }}
+          private-key: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
+
+      - name: Download process result
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: comparison
+          path: comparison
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+
+      # Important: This workflow job runs with extra permissions,
+      # so we need to make sure to not run untrusted code from PRs
+      - name: Check out Nixpkgs at the base commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.attrs.outputs.targetSha }}
+          path: base
+          sparse-checkout: ci
+
+      - name: Build the requestReviews derivation
+        run: nix-build base/ci -A requestReviews
+
+      - name: Labelling pull request
+        run: |
+          # Get all currently set rebuild labels
+          gh api \
+            /repos/"$REPOSITORY"/issues/"$NUMBER"/labels \
+            --jq '.[].name | select(startswith("10.rebuild"))' \
+            | sort > before
+
+          # And the labels that should be there
+          jq -r '.labels[]' comparison/changed-paths.json \
+            | sort > after
+
+          # Remove the ones not needed anymore
+          while read -r toRemove; do
+            echo "Removing label $toRemove"
+            gh api \
+              --method DELETE \
+              /repos/"$REPOSITORY"/issues/"$NUMBER"/labels/"$toRemove"
+          done < <(comm -23 before after)
+
+          # And add the ones that aren't set already
+          while read -r toAdd; do
+            echo "Adding label $toAdd"
+            gh api \
+              --method POST \
+              /repos/"$REPOSITORY"/issues/"$NUMBER"/labels \
+              -f "labels[]=$toAdd"
+          done < <(comm -13 before after)
+
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+
+      - name: Add eval summary to commit statuses
+        if: ${{ github.event_name == 'pull_request_target' }}
+        run: |
+          description=$(jq -r '
+          "Package: added " + (.attrdiff.added | length | tostring) +
+          ", removed " + (.attrdiff.removed | length | tostring) +
+          ", changed " + (.attrdiff.changed | length | tostring) +
+          ", Rebuild: linux " + (.rebuildCountByKernel.linux | tostring) +
+          ", darwin " + (.rebuildCountByKernel.darwin | tostring)
+          ' <comparison/changed-paths.json)
+          target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID?pr=$NUMBER"
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/statuses/$PR_HEAD_SHA" \
+            -f "context=Eval / Summary" -f "state=success" -f "description=$description" -f "target_url=$target_url"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          NUMBER: ${{ github.event.number }}
+
+      - name: Requesting maintainer reviews
+        run: |
+          # maintainers.json contains GitHub IDs. Look up handles to request reviews from.
+          # There appears to be no API to request reviews based on GitHub IDs
+          jq -r 'keys[]' comparison/maintainers.json \
+            | while read -r id; do gh api /user/"$id" --jq .login; done \
+            | GH_TOKEN=${{ steps.app-token.outputs.token }} result/bin/request-reviewers.sh "$REPOSITORY" "$NUMBER" "$AUTHOR"
+
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          # Don't request reviewers on draft PRs
+          DRY_MODE: ${{ github.event.pull_request.draft && '1' || '' }}

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -1,0 +1,43 @@
+name: Get merge commit
+
+on:
+  workflow_call:
+    outputs:
+      mergedSha:
+        description: "The merge commit SHA"
+        value: ${{ jobs.resolve-merge-commit.outputs.mergedSha }}
+
+permissions: {}
+
+jobs:
+  resolve-merge-commit:
+    runs-on: ubuntu-24.04
+    outputs:
+      mergedSha: ${{ steps.merged.outputs.mergedSha }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: base
+          sparse-checkout: ci
+
+      - name: Check if the PR can be merged and get the test merge commit
+        id: merged
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_EVENT: ${{ github.event_name }}
+        run: |
+          case "$GH_EVENT" in
+            push)
+              echo "mergedSha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+              ;;
+            pull_request_target)
+              if mergedSha=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
+                echo "Checking the merge commit $mergedSha"
+                echo "mergedSha=$mergedSha" >> "$GITHUB_OUTPUT"
+              else
+                # Skipping so that no notifications are sent
+                echo "Skipping the rest..."
+              fi
+              ;;
+          esac
+          rm -rf base

--- a/.github/workflows/keep-sorted.yml
+++ b/.github/workflows/keep-sorted.yml
@@ -1,0 +1,40 @@
+name: Check that files are sorted
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  nixos:
+    name: keep-sorted
+    runs-on: ubuntu-24.04
+    needs: get-merge-commit
+    if: "needs.get-merge-commit.outputs.mergedSha && !contains(github.event.pull_request.title, '[skip treewide]')"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+
+      - name: Get Nixpkgs revision for keep-sorted
+        run: |
+          # Pin to a commit from nixpkgs-unstable to avoid e.g. building nixfmt from staging.
+          # This should not be a URL, because it would allow PRs to run arbitrary code in CI!
+          rev=$(jq -r .rev ci/pinned-nixpkgs.json)
+          echo "url=https://github.com/NixOS/nixpkgs/archive/$rev.tar.gz" >> "$GITHUB_ENV"
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+          nix_path: nixpkgs=${{ env.url }}
+
+      - name: Install keep-sorted
+        run: "nix-env -f '<nixpkgs>' -iAP keep-sorted jq"
+
+      - name: Check that Nix files are sorted
+        run: |
+          git ls-files | xargs keep-sorted --mode lint | jq --raw-output '.[] | "Please make sure any new entries in \(.path) are sorted alphabetically."'

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,31 @@
+# WARNING:
+# When extending this action, be aware that $GITHUB_TOKEN allows some write
+# access to the GitHub API. This means that it should not evaluate user input in
+# a way that allows code injection.
+
+name: "Label PR"
+
+on:
+  pull_request_target:
+    types: [edited, opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labels:
+    name: label-pr
+    runs-on: ubuntu-24.04
+    if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml # default
+          sync-labels: true
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler-no-sync.yml
+          sync-labels: false

--- a/.github/workflows/lint-actions.sh
+++ b/.github/workflows/lint-actions.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash actionlint shellcheck -I nixpkgs=../..
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR/../.."
+actionlint

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -1,0 +1,56 @@
+name: "Build NixOS manual v2"
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    paths:
+      - "nixos/**"
+      # Also build when the nixpkgs doc changed, since we take things like
+      # the release notes and some css and js files from there.
+      # See nixos/doc/manual/default.nix
+      - "doc/**"
+      # Build when something in lib changes
+      # Since the lib functions are used to 'massage' the options before producing the manual
+      - "lib/**"
+
+permissions: {}
+
+jobs:
+  nixos:
+    name: nixos-manual-build
+    strategy:
+      fail-fast: false
+      matrix:
+        system:
+          - x86_64-linux
+          - aarch64-linux
+    runs-on: >-
+      ${{ (matrix.system == 'x86_64-linux' && 'ubuntu-24.04')
+      || (matrix.system == 'aarch64-linux' && 'ubuntu-24.04-arm') }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        if: github.repository_owner == 'NixOS'
+        with:
+          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
+          name: nixpkgs-ci
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build NixOS manual
+        id: build-manual
+        run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true nixos/release.nix -A manual.${{ matrix.system }}
+
+      - name: Upload NixOS manual
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nixos-manual-${{ matrix.system }}
+          path: result/
+          if-no-files-found: error

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -1,0 +1,35 @@
+name: "Build Nixpkgs manual v2"
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    paths:
+      - 'doc/**'
+      - 'lib/**'
+      - 'pkgs/tools/nix/nixdoc/**'
+
+permissions: {}
+
+jobs:
+  nixpkgs:
+    name: nixpkgs-manual-build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        if: github.repository_owner == 'NixOS'
+        with:
+          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
+          name: nixpkgs-ci
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Building Nixpkgs manual
+        run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true pkgs/top-level/release.nix -A manual -A manual.tests

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -1,0 +1,47 @@
+name: "Check whether nix files are parseable v2"
+
+on:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  tests:
+    name: nix-files-parseable-check
+    runs-on: ubuntu-24.04
+    needs: get-merge-commit
+    if: "needs.get-merge-commit.outputs.mergedSha && !contains(github.event.pull_request.title, '[skip treewide]')"
+    steps:
+      - name: Get list of changed files from PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/pulls/${{github.event.number}}/files --paginate \
+            | jq --raw-output '.[] | select(.status != "removed" and (.filename | endswith(".nix"))) | .filename' \
+            > "$HOME/changed_files"
+          if [[ -s "$HOME/changed_files" ]]; then
+            echo "CHANGED_FILES=$HOME/changed_files" > "$GITHUB_ENV"
+          fi
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+        if: ${{ env.CHANGED_FILES && env.CHANGED_FILES != '' }}
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: sandbox = true
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+
+      - name: Parse all changed or added nix files
+        run: |
+          ret=0
+          while IFS= read -r file; do
+            out="$(nix-instantiate --parse "$file")" || { echo "$out" && ret=1; }
+          done < "$HOME/changed_files"
+          exit "$ret"
+        if: ${{ env.CHANGED_FILES && env.CHANGED_FILES != '' }}

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -1,0 +1,73 @@
+# `nixpkgs-vet` is a tool to vet Nixpkgs: its architecture, package structure, and more.
+# Among other checks, it makes sure that `pkgs/by-name` (see `../../pkgs/by-name/README.md`) follows the validity rules outlined in [RFC 140](https://github.com/NixOS/rfcs/pull/140).
+# When you make changes to this workflow, please also update `ci/nixpkgs-vet.sh` to reflect the impact of your work to the CI.
+# See https://github.com/NixOS/nixpkgs-vet for details on the tool and its checks.
+
+name: Vet nixpkgs
+
+on:
+  pull_request_target:
+    # This workflow depends on the base branch of the PR, but changing the base branch is not included in the default trigger events, which would be `opened`, `synchronize` or `reopened`.
+    # Instead it causes an `edited` event, so we need to add it explicitly here.
+    # While `edited` is also triggered when the PR title/body is changed, this PR action is fairly quick, and PRs don't get edited **that** often, so it shouldn't be a problem.
+    # There is a feature request for adding a `base_changed` event: https://github.com/orgs/community/discussions/35058
+    types: [opened, synchronize, reopened, edited]
+
+permissions: {}
+
+# We don't use a concurrency group here, because the action is triggered quite often (due to the PR edit trigger), and contributors would get notified on any canceled run.
+# There is a feature request for suppressing notifications on concurrency-canceled runs: https://github.com/orgs/community/discussions/13015
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  check:
+    name: nixpkgs-vet
+    # This needs to be x86_64-linux, because we depend on the tooling being pre-built in the GitHub releases.
+    runs-on: ubuntu-24.04
+    # This should take 1 minute at most, but let's be generous. The default of 6 hours is definitely too long.
+    timeout-minutes: 10
+    needs: get-merge-commit
+    if: needs.get-merge-commit.outputs.mergedSha
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          # Fetches the merge commit and its parents
+          fetch-depth: 2
+
+      - name: Checking out target branch
+        run: |
+          target=$(mktemp -d)
+          git worktree add "$target" "$(git rev-parse HEAD^1)"
+          echo "target=$target" >> "$GITHUB_ENV"
+
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+
+      - name: Fetching the pinned tool
+        # Update the pinned version using ci/nixpkgs-vet/update-pinned-tool.sh
+        run: |
+          # The pinned version of the tooling to use.
+          toolVersion=$(<ci/nixpkgs-vet/pinned-version.txt)
+
+          # Fetch the x86_64-linux-specific release artifact containing the gzipped NAR of the pre-built tool.
+          toolPath=$(curl -sSfL https://github.com/NixOS/nixpkgs-vet/releases/download/"$toolVersion"/x86_64-linux.nar.gz \
+            | gzip -cd | nix-store --import | tail -1)
+
+          # Adds a result symlink as a GC root.
+          nix-store --realise "$toolPath" --add-root result
+
+      - name: Running nixpkgs-vet
+        env:
+          # Force terminal colors to be enabled. The library that `nixpkgs-vet` uses respects https://bixense.com/clicolors/
+          CLICOLOR_FORCE: 1
+        run: |
+          if result/bin/nixpkgs-vet --base "$target" .; then
+            exit 0
+          else
+            exitCode=$?
+            echo "To run locally: ./ci/nixpkgs-vet.sh $GITHUB_BASE_REF https://github.com/$GITHUB_REPOSITORY.git"
+            echo "If you're having trouble, ping @NixOS/nixpkgs-vet"
+            exit "$exitCode"
+          fi

--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -1,0 +1,25 @@
+name: "No channel PR"
+
+on:
+  pull_request_target:
+    # Re-run should be triggered when the base branch is updated, instead of silently failing
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - 'nixos-**'
+      - 'nixpkgs-**'
+
+permissions: {}
+
+jobs:
+  fail:
+    name: "This PR is is targeting a channel branch"
+    runs-on: ubuntu-24.04
+    steps:
+      - run: |
+          cat <<EOF
+          The nixos-* and nixpkgs-* branches are pushed to by the channel
+          release script and should not be merged into directly.
+
+          Please target the equivalent release-* branch or master instead.
+          EOF
+          exit 1

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -1,0 +1,40 @@
+# This action periodically merges base branches into staging branches.
+# This is done to
+#  * prevent conflicts or rather resolve them early
+#  * make all potential breakage happen on the staging branch
+#  * and make sure that all major rebuilds happen before the staging
+#    branch get’s merged back into its base branch.
+
+name: "Periodic Merges (24h)"
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Merge every 24 hours
+    - cron:  '0 0 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  periodic-merge:
+    if: github.repository_owner == 'NixOS'
+    strategy:
+      # don't fail fast, so that all pairs are tried
+      fail-fast: false
+      # certain branches need to be merged in order, like master->staging-next->staging
+      # and disabling parallelism ensures the order of the pairs below.
+      max-parallel: 1
+      matrix:
+        pairs:
+          - from: release-24.11
+            into: staging-next-24.11
+          - from: staging-next-24.11
+            into: staging-24.11
+          - from: master staging
+            into: haskell-updates
+    uses: ./.github/workflows/periodic-merge.yml
+    with:
+      from: ${{ matrix.pairs.from }}
+      into: ${{ matrix.pairs.into }}
+    secrets: inherit

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -1,0 +1,38 @@
+# This action periodically merges base branches into staging branches.
+# This is done to
+#  * prevent conflicts or rather resolve them early
+#  * make all potential breakage happen on the staging branch
+#  * and make sure that all major rebuilds happen before the staging
+#    branch get’s merged back into its base branch.
+
+name: "Periodic Merges (6h)"
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Merge every 6 hours
+    - cron:  '0 */6 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  periodic-merge:
+    if: github.repository_owner == 'NixOS'
+    strategy:
+      # don't fail fast, so that all pairs are tried
+      fail-fast: false
+      # certain branches need to be merged in order, like master->staging-next->staging
+      # and disabling parallelism ensures the order of the pairs below.
+      max-parallel: 1
+      matrix:
+        pairs:
+          - from: master
+            into: staging-next
+          - from: staging-next
+            into: staging
+    uses: ./.github/workflows/periodic-merge.yml
+    with:
+      from: ${{ matrix.pairs.from }}
+      into: ${{ matrix.pairs.into }}
+    secrets: inherit

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -1,0 +1,58 @@
+name: "Merge"
+
+on:
+  workflow_call:
+    inputs:
+      from:
+        description: Branch to merge into target branch. Can also be two branches separated by space to find the merge base between them.
+        required: true
+        type: string
+      into:
+        description: Target branch to merge into.
+        required: true
+        type: string
+
+jobs:
+  merge:
+    runs-on: ubuntu-24.04
+    name: ${{ inputs.from }} → ${{ inputs.into }}
+    steps:
+      # Use a GitHub App to create the PR so that CI gets triggered
+      # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Find merge base between two branches
+        if: contains(inputs.from, ' ')
+        id: merge_base
+        env:
+          branches: ${{ inputs.from }}
+        run: |
+          # turn into bash array, split on space
+          read -ra branches <<< "$branches"
+          git fetch --shallow-since="1 month ago" origin "${branches[@]}"
+          merge_base="$(git merge-base "refs/remotes/origin/${branches[0]}" "refs/remotes/origin/${branches[1]}")"
+          echo "Found merge base: $merge_base" >&2
+          echo "merge_base=$merge_base" >> "$GITHUB_OUTPUT"
+
+      - name: ${{ inputs.from }} → ${{ inputs.into }}
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # 1.4.0
+        with:
+          type: now
+          from_branch: ${{ steps.merge_base.outputs.merge_base || inputs.from }}
+          target_branch: ${{ inputs.into }}
+          github_token: ${{ steps.app-token.outputs.token }}
+
+      - name: Comment on failure
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: ${{ failure() }}
+        with:
+          issue-number: 105153
+          body: |
+            Periodic merge from `${{ inputs.from }}` into `${{ inputs.into }}` has [failed](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }}).
+          token: ${{ steps.app-token.outputs.token }}

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -1,0 +1,468 @@
+# This file is used to describe who owns what in this repository.
+# Users/teams will get review requests for PRs that change their files.
+#
+# This file does not replace `meta.maintainers`
+# but is instead used for other things than derivations and modules,
+# like documentation, package sets, and other assets.
+#
+# This file uses the same syntax as the natively supported CODEOWNERS file,
+# see https://help.github.com/articles/about-codeowners/ for documentation.
+# However it comes with some notable differences:
+# - There is no need for user/team listed here to have write access.
+# - No reviews will be requested for PRs that target the wrong base branch.
+#
+# Processing of this file is implemented in workflows/codeowners-v2.yml
+
+# CI
+/.github/*_TEMPLATE*                    @SigmaSquadron
+/.github/workflows                      @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther
+/.github/workflows/check-nix-format.yml @infinisil @wolfgangwalther
+/.github/workflows/codeowners-v2.yml    @infinisil @wolfgangwalther
+/.github/workflows/nixpkgs-vet.yml      @infinisil @philiptaron @wolfgangwalther
+/ci                                     @infinisil @philiptaron @NixOS/Security @wolfgangwalther
+/ci/OWNERS                              @infinisil @philiptaron
+
+# Development support
+/.editorconfig @Mic92 @zowoq
+/shell.nix @infinisil @NixOS/Security
+
+# Libraries
+/lib                        @infinisil @hsjobeki
+/lib/systems                @alyssais @ericson2314 @NixOS/stdenv
+/lib/generators.nix         @infinisil @hsjobeki @Profpatsch
+/lib/cli.nix                @infinisil @hsjobeki @Profpatsch
+/lib/debug.nix              @infinisil @hsjobeki @Profpatsch
+/lib/asserts.nix            @infinisil @hsjobeki @Profpatsch
+/lib/path/*                 @infinisil @hsjobeki
+/lib/fileset                @infinisil @hsjobeki
+## Libraries / Module system
+/lib/modules.nix            @infinisil @roberth @hsjobeki
+/lib/types.nix              @infinisil @roberth @hsjobeki
+/lib/options.nix            @infinisil @roberth @hsjobeki
+/lib/tests/modules.sh       @infinisil @roberth @hsjobeki
+/lib/tests/modules          @infinisil @roberth @hsjobeki
+
+# Nixpkgs Internals
+/default.nix                                     @Ericson2314
+/pkgs/top-level/default.nix                      @Ericson2314
+/pkgs/top-level/impure.nix                       @Ericson2314
+/pkgs/top-level/stage.nix                        @Ericson2314
+/pkgs/top-level/splice.nix                       @Ericson2314
+/pkgs/top-level/release-cross.nix                @Ericson2314
+/pkgs/top-level/by-name-overlay.nix              @infinisil @philiptaron
+/pkgs/stdenv                                     @philiptaron @NixOS/stdenv
+/pkgs/stdenv/generic                             @Ericson2314 @NixOS/stdenv
+/pkgs/stdenv/generic/check-meta.nix              @Ericson2314 @NixOS/stdenv
+/pkgs/stdenv/cross                               @Ericson2314 @NixOS/stdenv
+/pkgs/build-support                              @philiptaron
+/pkgs/build-support/cc-wrapper                   @Ericson2314
+/pkgs/build-support/bintools-wrapper             @Ericson2314
+/pkgs/build-support/setup-hooks                  @Ericson2314
+/pkgs/build-support/setup-hooks/auto-patchelf.sh @layus
+/pkgs/by-name/au/auto-patchelf                   @layus
+
+## Format generators/serializers
+/pkgs/pkgs-lib                                   @Stunkymonkey @h7x4
+
+# Nixpkgs build-support
+/pkgs/build-support/writers @lassulus @Profpatsch
+
+# Nixpkgs make-disk-image
+/doc/build-helpers/images/makediskimage.section.md  @raitobezarius
+/nixos/lib/make-disk-image.nix                 @raitobezarius
+
+# Nix, the package manager
+# @raitobezarius is not "code owner", but is listed here to be notified of changes
+# pertaining to the Nix package manager.
+# i.e. no authority over those files.
+pkgs/tools/package-management/nix/                    @NixOS/nix-team @raitobezarius
+nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobezarius
+
+# Nixpkgs documentation
+/maintainers/scripts/db-to-md.sh @jtojnar @ryantm
+/maintainers/scripts/doc @jtojnar @ryantm
+
+# Contributor documentation
+/CONTRIBUTING.md @infinisil
+/.github/PULL_REQUEST_TEMPLATE.md @infinisil
+/doc/contributing/ @infinisil
+/doc/contributing/contributing-to-documentation.chapter.md @jtojnar @infinisil
+/lib/README.md @infinisil
+/doc/README.md @infinisil
+/nixos/README.md @infinisil
+/pkgs/README.md @infinisil
+/pkgs/by-name/README.md @infinisil
+/maintainers/README.md @infinisil
+
+# User-facing development documentation
+/doc/development.md @infinisil
+/doc/development @infinisil
+
+# NixOS Internals
+/nixos/default.nix                                    @infinisil
+/nixos/lib/from-env.nix                               @infinisil
+/nixos/lib/eval-config.nix                            @infinisil
+/nixos/modules/misc/ids.nix                           @R-VdP
+/nixos/modules/system/activation/bootspec.nix         @grahamc @cole-h @raitobezarius
+/nixos/modules/system/activation/bootspec.cue         @grahamc @cole-h @raitobezarius
+
+# NixOS Render Docs
+/pkgs/by-name/ni/nixos-render-docs @fricklerhandwerk @GetPsyched @hsjobeki
+/doc/redirects.json                @fricklerhandwerk @GetPsyched @hsjobeki
+/nixos/doc/manual/redirects.json   @fricklerhandwerk @GetPsyched @hsjobeki
+
+# NixOS integration test driver
+/nixos/lib/test-driver  @tfc
+
+# NixOS QEMU virtualisation
+/nixos/modules/virtualisation/qemu-vm.nix           @raitobezarius
+
+# ACME
+/nixos/modules/security/acme                @NixOS/acme
+
+# Systemd
+/nixos/modules/system/boot/systemd.nix      @NixOS/systemd
+/nixos/modules/system/boot/systemd          @NixOS/systemd
+/nixos/lib/systemd-*.nix                    @NixOS/systemd
+/pkgs/os-specific/linux/systemd             @NixOS/systemd
+
+# Systemd-boot
+/nixos/modules/system/boot/loader/systemd-boot      @JulienMalka
+
+# Limine
+/nixos/modules/system/boot/loader/limine        @lzcunt @phip1611 @programmerlexi
+
+# Images and installer media
+/nixos/modules/profiles/installation-device.nix @ElvishJerricco
+/nixos/modules/installer/cd-dvd/                @ElvishJerricco
+/nixos/modules/installer/sd-card/
+
+# Amazon
+/nixos/modules/virtualisation/amazon-init.nix                  @arianvp
+/nixos/modules/virtualisation/ec2-data.nix                     @arianvp
+/nixos/modules/virtualisation/amazon-options.nix               @arianvp
+/nixos/modules/virtualisation/amazon-image.nix                 @arianvp
+/nixos/maintainers/scripts/ec2/                                @arianvp
+/nixos/modules/services/misc/amazon-ssm-agent.nix              @arianvp
+/nixos/tests/amazon-ssm-agent.nix                              @arianvp
+/nixos/modules/system/boot/grow-partition.nix                  @arianvp
+/nixos/modules/services/monitoring/amazon-cloudwatch-agent.nix @philipmw
+/nixos/tests/amazon-cloudwatch-agent.nix                       @philipmw
+
+# Monitoring
+/nixos/modules/services/monitoring/fluent-bit.nix @arianvp
+/nixos/tests/fluent-bit.nix                       @arianvp
+
+# nixos-rebuild-ng
+/pkgs/by-name/ni/nixos-rebuild-ng                 @thiagokokada
+
+# Updaters
+## update.nix
+/maintainers/scripts/update.nix   @jtojnar
+/maintainers/scripts/update.py    @jtojnar
+## common-updater-scripts
+/pkgs/common-updater/scripts/update-source-version    @jtojnar
+
+# Python-related code and docs
+/doc/languages-frameworks/python.section.md   @mweinelt @natsukium
+/maintainers/scripts/update-python-libraries  @mweinelt @natsukium
+/pkgs/by-name/up/update-python-libraries      @mweinelt @natsukium
+/pkgs/development/interpreters/python         @mweinelt @natsukium
+/pkgs/top-level/python-packages.nix                     @natsukium
+/pkgs/top-level/release-python.nix                      @natsukium
+
+# Haskell
+/doc/languages-frameworks/haskell.section.md  @sternenseemann @maralorn
+/maintainers/scripts/haskell                  @sternenseemann @maralorn
+/pkgs/development/compilers/ghc               @sternenseemann @maralorn
+/pkgs/development/haskell-modules             @sternenseemann @maralorn
+/pkgs/test/haskell                            @sternenseemann @maralorn
+/pkgs/top-level/release-haskell.nix           @sternenseemann @maralorn
+/pkgs/top-level/haskell-packages.nix          @sternenseemann @maralorn
+
+# Perl
+/pkgs/development/interpreters/perl @stigtsp @zakame @marcusramberg
+/pkgs/top-level/perl-packages.nix   @stigtsp @zakame @marcusramberg
+/pkgs/development/perl-modules      @stigtsp @zakame @marcusramberg
+
+# R
+/pkgs/applications/science/math/R   @jbedo
+/pkgs/development/r-modules         @jbedo
+
+# Rust
+/pkgs/development/compilers/rust @alyssais @Mic92 @zowoq @winterqt @figsoda
+/pkgs/build-support/rust @zowoq @winterqt @figsoda
+/pkgs/build-support/rust/fetch-cargo-vendor* @TomaSajt
+/doc/languages-frameworks/rust.section.md @zowoq @winterqt @figsoda
+
+# Tcl
+/pkgs/development/interpreters/tcl  @fgaz
+/pkgs/development/libraries/tk      @fgaz
+/pkgs/top-level/tcl-packages.nix    @fgaz
+/pkgs/development/tcl-modules       @fgaz
+/doc/languages-frameworks/tcl.section.md @fgaz
+
+# C compilers
+/pkgs/development/compilers/gcc
+/pkgs/development/compilers/llvm @alyssais @RossComputerGuy @NixOS/llvm
+/pkgs/development/compilers/emscripten @raitobezarius
+/doc/languages-frameworks/emscripten.section.md @raitobezarius
+
+# Audio
+/nixos/modules/services/audio/botamusique.nix @mweinelt
+/nixos/modules/services/audio/snapserver.nix @mweinelt
+/nixos/tests/botamusique.nix @mweinelt
+/nixos/tests/snapcast.nix @mweinelt
+
+# Browsers
+/pkgs/applications/networking/browsers/firefox @mweinelt
+/pkgs/applications/networking/browsers/chromium @emilylange @networkException
+/nixos/tests/chromium.nix @emilylange @networkException
+
+# Certificate Authorities
+pkgs/by-name/ca/cacert @ajs124 @lukegb @mweinelt
+pkgs/development/libraries/nss/ @ajs124 @lukegb @mweinelt
+pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
+
+# Java
+/doc/languages-frameworks/java.section.md @NixOS/java
+/doc/languages-frameworks/gradle.section.md @NixOS/java
+/doc/languages-frameworks/maven.section.md @NixOS/java
+/nixos/modules/programs/java.nix @NixOS/java
+/pkgs/top-level/java-packages.nix @NixOS/java
+
+# Jetbrains
+/pkgs/applications/editors/jetbrains @edwtjo @leona-ya @theCapypara
+
+# Licenses
+/lib/licenses.nix @alyssais
+
+# Qt
+/pkgs/development/libraries/qt-5 @K900 @NickCao @SuperSandro2000 @ttuegel
+/pkgs/development/libraries/qt-6 @K900 @NickCao @SuperSandro2000 @ttuegel
+
+# KDE / Plasma 5
+/pkgs/applications/kde @K900 @NickCao @SuperSandro2000 @ttuegel
+/pkgs/desktops/plasma-5 @K900 @NickCao @SuperSandro2000 @ttuegel
+/pkgs/development/libraries/kde-frameworks @K900 @NickCao @SuperSandro2000 @ttuegel
+
+# KDE / Plasma 6
+/pkgs/kde @K900 @NickCao @SuperSandro2000 @ttuegel
+/maintainers/scripts/kde @K900 @NickCao @SuperSandro2000 @ttuegel
+
+# PostgreSQL and related stuff
+/pkgs/by-name/ps/psqlodbc @NixOS/postgres
+/pkgs/servers/sql/postgresql @NixOS/postgres
+/pkgs/development/tools/rust/cargo-pgrx @NixOS/postgres
+/nixos/modules/services/databases/postgresql.md @NixOS/postgres
+/nixos/modules/services/databases/postgresql.nix @NixOS/postgres
+/nixos/tests/postgresql @NixOS/postgres
+
+# MySQL/MariaDB and related stuff
+/nixos/modules/services/databases/mysql.nix     @6543
+/nixos/modules/services/backup/mysql-backup.nix @6543
+
+# Hardened profile & related modules
+/nixos/modules/profiles/hardened.nix                       @joachifm
+/nixos/modules/security/lock-kernel-modules.nix            @joachifm
+/nixos/modules/security/misc.nix                           @joachifm
+/nixos/tests/hardened.nix                                  @joachifm
+/pkgs/os-specific/linux/kernel/hardened/        @fabianhjr @joachifm
+
+# Home Automation
+/nixos/modules/services/home-automation/home-assistant.nix @mweinelt
+/nixos/modules/services/home-automation/zigbee2mqtt.nix @mweinelt
+/nixos/tests/home-assistant.nix @mweinelt
+/nixos/tests/zigbee2mqtt.nix @mweinelt
+/pkgs/servers/home-assistant @mweinelt
+/pkgs/by-name/es/esphome @mweinelt
+
+# Network Time Daemons
+/pkgs/by-name/ch/chrony @thoughtpolice
+/pkgs/by-name/nt/ntp @thoughtpolice
+/pkgs/by-name/op/openntpd @thoughtpolice
+/nixos/modules/services/networking/ntp @thoughtpolice
+
+# Network
+/pkgs/by-name/ke/kea @mweinelt
+/pkgs/by-name/ba/babeld @mweinelt
+/nixos/modules/services/networking/babeld.nix @mweinelt
+/nixos/modules/services/networking/kea.nix @mweinelt
+/nixos/modules/services/networking/knot.nix @mweinelt
+/nixos/modules/services/monitoring/prometheus/exporters/kea.nix @mweinelt
+/nixos/tests/babeld.nix @mweinelt
+/nixos/tests/kea.nix @mweinelt
+/nixos/tests/knot.nix @mweinelt
+
+# Web servers
+/doc/packages/nginx.section.md @raitobezarius
+/pkgs/servers/http/nginx/ @raitobezarius
+/nixos/modules/services/web-servers/nginx/ @raitobezarius
+
+# D
+/pkgs/build-support/dlang @jtbx @TomaSajt
+
+# Dhall
+/pkgs/development/dhall-modules      @Gabriella439 @Profpatsch @ehmry
+/pkgs/development/interpreters/dhall @Gabriella439 @Profpatsch @ehmry
+
+# Idris
+/pkgs/development/idris-modules @Infinisil
+/pkgs/development/compilers/idris2 @mattpolzin
+
+# Bazel
+/pkgs/development/tools/build-managers/bazel @Profpatsch
+
+# NixOS modules for e-mail and dns services
+/nixos/modules/services/mail/mailman.nix    @peti
+/nixos/modules/services/mail/postfix.nix    @peti
+/nixos/modules/services/networking/bind.nix @peti
+/nixos/modules/services/mail/rspamd.nix     @peti
+
+# Emacs
+/pkgs/applications/editors/emacs/elisp-packages @NixOS/emacs
+/pkgs/applications/editors/emacs                @NixOS/emacs
+/pkgs/top-level/emacs-packages.nix              @NixOS/emacs
+/doc/packages/emacs.section.md                  @NixOS/emacs
+/nixos/modules/services/editors/emacs.md        @NixOS/emacs
+
+# Kakoune
+/pkgs/applications/editors/kakoune     @philiptaron
+
+# LuaPackages
+/pkgs/development/lua-modules         @NixOS/lua
+
+# Neovim
+/pkgs/applications/editors/neovim      @NixOS/neovim
+
+# VimPlugins
+/pkgs/applications/editors/vim/plugins         @NixOS/neovim
+
+# VsCode Extensions
+/pkgs/applications/editors/vscode/extensions
+
+# PHP interpreter, packages, extensions, tests and documentation
+/doc/languages-frameworks/php.section.md          @aanderse @drupol @globin @ma27 @talyz
+/nixos/tests/php                                  @aanderse @drupol @globin @ma27 @talyz
+/pkgs/build-support/php/build-pecl.nix            @aanderse @drupol @globin @ma27 @talyz
+/pkgs/build-support/php                                     @drupol
+/pkgs/development/interpreters/php       @jtojnar @aanderse @drupol @globin @ma27 @talyz
+/pkgs/development/php-packages                    @aanderse @drupol @globin @ma27 @talyz
+/pkgs/top-level/php-packages.nix         @jtojnar @aanderse @drupol @globin @ma27 @talyz
+
+# Docker tools
+/pkgs/build-support/docker                   @roberth
+/nixos/tests/docker-tools*                   @roberth
+/doc/build-helpers/images/dockertools.section.md  @roberth
+
+# Blockchains
+/pkgs/applications/blockchains  @mmahut @RaghavSood
+
+# Go
+/doc/languages-frameworks/go.section.md @kalbasit @katexochen @Mic92 @zowoq
+/pkgs/build-support/go @kalbasit @katexochen @Mic92 @zowoq
+/pkgs/development/compilers/go @kalbasit @katexochen @Mic92 @zowoq
+
+# GNOME
+/pkgs/desktops/gnome                              @jtojnar
+/pkgs/desktops/gnome/extensions                   @jtojnar
+/pkgs/build-support/make-hardcode-gsettings-patch @jtojnar
+
+# Cinnamon
+/pkgs/by-name/ci/cinnamon-*    @mkg20001
+/pkgs/by-name/cj/cjs           @mkg20001
+/pkgs/by-name/mu/muffin        @mkg20001
+/pkgs/by-name/ne/nemo          @mkg20001
+/pkgs/by-name/ne/nemo-*        @mkg20001
+
+# Xfce
+/doc/hooks/xfce4-dev-tools.section.md @NixOS/xfce
+
+# nim
+/doc/languages-frameworks/nim.section.md  @ehmry
+/pkgs/build-support/build-nim-package.nix @ehmry
+/pkgs/build-support/build-nim-sbom.nix    @ehmry
+/pkgs/top-level/nim-overrides.nix         @ehmry
+
+# terraform providers
+/pkgs/applications/networking/cluster/terraform-providers @zowoq
+
+# Forgejo
+nixos/modules/services/misc/forgejo.nix @adamcstephens @bendlas @emilylange
+pkgs/by-name/fo/forgejo/                @adamcstephens @bendlas @emilylange
+
+# Dotnet
+/pkgs/build-support/dotnet                  @corngood
+/pkgs/development/compilers/dotnet          @corngood
+/pkgs/test/dotnet                           @corngood
+/doc/languages-frameworks/dotnet.section.md @corngood
+
+# Node.js
+/pkgs/build-support/node/build-npm-package      @winterqt
+/pkgs/build-support/node/fetch-npm-deps         @winterqt
+/doc/languages-frameworks/javascript.section.md @winterqt
+/pkgs/development/tools/pnpm                    @Scrumplex @gepbird
+
+# OCaml
+/pkgs/build-support/ocaml           @ulrikstrid
+/pkgs/development/compilers/ocaml   @ulrikstrid
+/pkgs/development/ocaml-modules     @ulrikstrid
+
+# ZFS
+/nixos/modules/tasks/filesystems/zfs.nix @adamcstephens @amarshall
+/nixos/tests/zfs.nix                     @adamcstephens @amarshall
+/pkgs/os-specific/linux/zfs              @adamcstephens @amarshall
+
+# Zig
+/pkgs/development/compilers/zig @figsoda @RossComputerGuy
+/doc/hooks/zig.section.md       @figsoda @RossComputerGuy
+
+# Buildbot
+nixos/modules/services/continuous-integration/buildbot @Mic92 @zowoq
+nixos/tests/buildbot.nix                               @Mic92 @zowoq
+pkgs/development/tools/continuous-integration/buildbot @Mic92 @zowoq
+
+# Pretix
+pkgs/by-name/pr/pretix/ @mweinelt
+pkgs/by-name/pr/pretalx/ @mweinelt
+nixos/modules/services/web-apps/pretix.nix @mweinelt
+nixos/modules/services/web-apps/pretalx.nix @mweinelt
+nixos/tests/web-apps/pretix.nix @mweinelt
+nixos/tests/web-apps/pretalx.nix @mweinelt
+
+# incus/lxc
+nixos/maintainers/scripts/incus/        @adamcstephens
+nixos/modules/virtualisation/incus.nix  @adamcstephens
+nixos/modules/virtualisation/lxc*       @adamcstephens
+nixos/tests/incus/                      @adamcstephens
+pkgs/by-name/in/incus/                  @adamcstephens
+pkgs/by-name/lx/lxc*                    @adamcstephens
+
+# ExpidusOS, Flutter
+/pkgs/development/compilers/flutter @RossComputerGuy
+/pkgs/desktops/expidus              @RossComputerGuy
+
+# GNU Tar & Zip
+/pkgs/tools/archivers/gnutar        @RossComputerGuy
+/pkgs/by-name/zi/zip           @RossComputerGuy
+
+# SELinux
+/pkgs/by-name/ch/checkpolicy @RossComputerGuy
+/pkgs/by-name/li/libselinux  @RossComputerGuy
+/pkgs/by-name/li/libsepol    @RossComputerGuy
+
+# installShellFiles
+/pkgs/by-name/in/installShellFiles/*     @Ericson2314
+/pkgs/test/install-shell-files/*         @Ericson2314
+/doc/hooks/installShellFiles.section.md  @Ericson2314
+
+# Darwin
+/pkgs/by-name/ap/apple-sdk                     @NixOS/darwin-core
+/pkgs/os-specific/darwin/apple-source-releases @NixOS/darwin-core
+/pkgs/stdenv/darwin                            @NixOS/darwin-core
+
+# BEAM
+pkgs/development/beam-modules/          @NixOS/beam
+pkgs/development/interpreters/erlang/   @NixOS/beam
+pkgs/development/interpreters/elixir/   @NixOS/beam
+pkgs/development/interpreters/lfe/      @NixOS/beam

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -118,16 +118,6 @@ rec {
 
       mkList ? k: v: lib.concatMap (mkOption k) v,
 
-      # any preprocessing of an attribute value of type "override"
-      # before we attempt to convert it to a command line option;
-      # by default we extract its "content" attribute.
-      #
-      # See also the mention of this attribute in the comments for `mkOption`.
-      unwrapOverride ? v: v.content,
-
-      # NOTE: If you modify this attribute to support attrsets that might
-      # have a "_type" attribute named "override", then consider whether
-      # to also specify a non-default value for `unwrapOverride`.
       mkOption ?
         k: v:
         if v == null then
@@ -145,19 +135,13 @@ rec {
     options:
     let
       render =
-        k: raw:
-        let
-          v = if lib.isType "override" raw then
-              unwrapOverride raw
-            else
-              raw;
-        in
-          if builtins.isBool v then
-            mkBool k v
-          else if builtins.isList v then
-            mkList k v
-          else
-            mkOption k v;
+        k: v:
+        if builtins.isBool v then
+          mkBool k v
+        else if builtins.isList v then
+          mkList k v
+        else
+          mkOption k v;
 
     in
     builtins.concatLists (lib.mapAttrsToList render options);

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -42,7 +42,7 @@ in
     };
   };
 
-  config = rec {
+  config = {
     rawTestDerivation = hostPkgs.stdenv.mkDerivation {
       name = "vm-test-run-${config.name}";
 
@@ -64,8 +64,11 @@ in
 
       meta = config.meta;
     };
-
-    test = rawTestDerivation;
+    test = lib.lazyDerivation {
+      # lazyDerivation improves performance when only passthru items and/or meta are used.
+      derivation = config.rawTestDerivation;
+      inherit (config) passthru meta;
+    };
 
     # useful for inspection (debugging / exploration)
     passthru.config = config;

--- a/pkgs/by-name/ni/nixos-install/nixos-install.sh
+++ b/pkgs/by-name/ni/nixos-install/nixos-install.sh
@@ -106,8 +106,6 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
-extraBuildFlags+=('--option' 'min-free' '0')
-
 if ! test -e "$mountPoint"; then
     echo "mount point $mountPoint doesn't exist"
     exit 1


### PR DESCRIPTION
- `.github: Remove.`
  - I've disabled GH Actions in this repo, so it shouldn't have any effect
  - This caused conflict in every bump
- `toGNUCommandLine: Unwrap value if set by mkForce/mkOverride`
  - Doesn't seem relevant anymore
- `testing/run: remove lazyDerivation`
  - The test derivation also exposes `rawTestDerivation` to avoid issues with lazyDerivation
- `nixos-install: Disable min-free`
  - Doesn't seem relevant anymore