### PR TITLE
Revert "lixPackageSets.lix_2_92: patch for CVE-2025-4641{5,6}"

### DIFF
--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -153,13 +153,13 @@ lib.makeExtensible (self: {
 
   lix_2_92 = self.makeLixScope {
     lix-args = rec {
-      version = "2.92.2";
+      version = "2.92.0";
 
       src = fetchFromGitHub {
         owner = "lix-project";
         repo = "lix";
         rev = version;
-        hash = "sha256-D7YepvFkGE4K1rOkEYA1P6wGj/eFbQXb03nLdBRjjwA=";
+        hash = "sha256-CCKIAE84dzkrnlxJCKFyffAxP3yfsOAbdvydUGqq24g=";
       };
 
       cargoDeps = rustPlatform.fetchCargoVendor {


### PR DESCRIPTION
This reverts commit 01c1efce1badef986e08694b72cb43b00a82e7ec.

While we track down and fix related issues.