### PR TITLE
[release-5.4] Backport fixes for jq CVEs

### DIFF
--- a/pkgs/by-name/jq/jq/0001-Improve-performance-of-repeating-strings-3272.patch
+++ b/pkgs/by-name/jq/jq/0001-Improve-performance-of-repeating-strings-3272.patch
@@ -1,0 +1,118 @@
+From c15fc903e00fdd3b460e64d5a6a540f944e1eca6 Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Tue, 4 Mar 2025 22:13:55 +0900
+Subject: [PATCH 1/4] Improve performance of repeating strings (#3272)
+
+This commit improves the performance of repeating strings, by copying
+the result string instead of the string being repeated. Also it adds
+an error message when the result string is too long.
+---
+ src/builtin.c | 15 ++-------------
+ src/jv.c      | 26 ++++++++++++++++++++++++++
+ src/jv.h      |  1 +
+ tests/jq.test | 12 ++++++++++++
+ 4 files changed, 41 insertions(+), 13 deletions(-)
+
+diff --git a/src/builtin.c b/src/builtin.c
+index 902490d..abb99f4 100644
+--- a/src/builtin.c
++++ b/src/builtin.c
+@@ -369,21 +369,10 @@ jv binop_multiply(jv a, jv b) {
+       str = b;
+       num = a;
+     }
+-    jv res;
+     double d = jv_number_value(num);
+-    if (d < 0 || isnan(d)) {
+-      res = jv_null();
+-    } else {
+-      int n = d;
+-      size_t alen = jv_string_length_bytes(jv_copy(str));
+-      res = jv_string_empty(alen * n);
+-      for (; n > 0; n--) {
+-        res = jv_string_append_buf(res, jv_string_value(str), alen);
+-      }
+-    }
+-    jv_free(str);
+     jv_free(num);
+-    return res;
++    return jv_string_repeat(str,
++        d < 0 || isnan(d) ? -1 : d > INT_MAX ? INT_MAX : (int)d);
+   } else if (ak == JV_KIND_OBJECT && bk == JV_KIND_OBJECT) {
+     return jv_object_merge_recursive(a, b);
+   } else {
+diff --git a/src/jv.c b/src/jv.c
+index e23d8ec..e0478c8 100644
+--- a/src/jv.c
++++ b/src/jv.c
+@@ -1291,6 +1291,32 @@ jv jv_string_indexes(jv j, jv k) {
+   return a;
+ }
+ 
++jv jv_string_repeat(jv j, int n) {
++  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
++  if (n < 0) {
++    jv_free(j);
++    return jv_null();
++  }
++  int len = jv_string_length_bytes(jv_copy(j));
++  int64_t res_len = (int64_t)len * n;
++  if (res_len >= INT_MAX) {
++    jv_free(j);
++    return jv_invalid_with_msg(jv_string("Repeat string result too long"));
++  }
++  if (res_len == 0) {
++    jv_free(j);
++    return jv_string("");
++  }
++  jv res = jv_string_empty(res_len);
++  res = jvp_string_append(res, jv_string_value(j), len);
++  for (int curr = len, grow; curr < res_len; curr += grow) {
++    grow = MIN(res_len - curr, curr);
++    res = jvp_string_append(res, jv_string_value(res), grow);
++  }
++  jv_free(j);
++  return res;
++}
++
+ jv jv_string_split(jv j, jv sep) {
+   assert(JVP_HAS_KIND(j, JV_KIND_STRING));
+   assert(JVP_HAS_KIND(sep, JV_KIND_STRING));
+diff --git a/src/jv.h b/src/jv.h
+index 083509e..a9b13ae 100644
+--- a/src/jv.h
++++ b/src/jv.h
+@@ -131,6 +131,7 @@ jv jv_string_fmt(const char*, ...) JV_PRINTF_LIKE(1, 2);
+ jv jv_string_append_codepoint(jv a, uint32_t c);
+ jv jv_string_append_buf(jv a, const char* buf, int len);
+ jv jv_string_append_str(jv a, const char* str);
++jv jv_string_repeat(jv j, int n);
+ jv jv_string_split(jv j, jv sep);
+ jv jv_string_explode(jv j);
+ jv jv_string_implode(jv j);
+diff --git a/tests/jq.test b/tests/jq.test
+index 7036df2..e82cf84 100644
+--- a/tests/jq.test
++++ b/tests/jq.test
+@@ -1365,6 +1365,18 @@ indices(", ")
+ "abc"
+ [null,null]
+ 
++. * 100000 | [.[:10],.[-10:]]
++"abc"
++["abcabcabca","cabcabcabc"]
++
++. * 1000000000
++""
++""
++
++try (. * 1000000000) catch .
++"abc"
++"Repeat string result too long"
++
+ [.[] / ","]
+ ["a, bc, def, ghij, jklmn, a,b, c,d, e,f", "a,b,c,d, e,f,g,h"]
+ [["a"," bc"," def"," ghij"," jklmn"," a","b"," c","d"," e","f"],["a","b","c","d"," e","f","g","h"]]
+-- 
+2.49.0
+

--- a/pkgs/by-name/jq/jq/0001-Improve-performance-of-repeating-strings-3272.patch
+++ b/pkgs/by-name/jq/jq/0001-Improve-performance-of-repeating-strings-3272.patch
@@ -1,7 +1,7 @@
 From c15fc903e00fdd3b460e64d5a6a540f944e1eca6 Mon Sep 17 00:00:00 2001
 From: itchyny <itchyny@cybozu.co.jp>
 Date: Tue, 4 Mar 2025 22:13:55 +0900
-Subject: [PATCH 1/4] Improve performance of repeating strings (#3272)
+Subject: [PATCH 1/5] Improve performance of repeating strings (#3272)
 
 This commit improves the performance of repeating strings, by copying
 the result string instead of the string being repeated. Also it adds

--- a/pkgs/by-name/jq/jq/0002-fix-jv_number_value-should-cache-the-double-value-of.patch
+++ b/pkgs/by-name/jq/jq/0002-fix-jv_number_value-should-cache-the-double-value-of.patch
@@ -1,7 +1,7 @@
 From df0ddb83feb656230157f5bc9b7f34caef1f82be Mon Sep 17 00:00:00 2001
 From: itchyny <itchyny@cybozu.co.jp>
 Date: Sun, 16 Feb 2025 22:08:36 +0900
-Subject: [PATCH 2/4] fix: `jv_number_value` should cache the double value of
+Subject: [PATCH 2/5] fix: `jv_number_value` should cache the double value of
  literal numbers (#3245)
 
 The code of `jv_number_value` is intended to cache the double value of

--- a/pkgs/by-name/jq/jq/0002-fix-jv_number_value-should-cache-the-double-value-of.patch
+++ b/pkgs/by-name/jq/jq/0002-fix-jv_number_value-should-cache-the-double-value-of.patch
@@ -1,0 +1,66 @@
+From df0ddb83feb656230157f5bc9b7f34caef1f82be Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Sun, 16 Feb 2025 22:08:36 +0900
+Subject: [PATCH 2/4] fix: `jv_number_value` should cache the double value of
+ literal numbers (#3245)
+
+The code of `jv_number_value` is intended to cache the double value of
+literal numbers, but it does not work because it accepts the `jv` struct
+by value. This patch fixes the behavior by checking if the double value
+is `NaN`, which indicates the unconverted value. This patch improves the
+performance of major use cases; e.g. `range(1000000)` runs 25% faster.
+---
+ src/jv.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/jv.c b/src/jv.c
+index e0478c8..418d57d 100644
+--- a/src/jv.c
++++ b/src/jv.c
+@@ -206,9 +206,6 @@ enum {
+   JVP_NUMBER_DECIMAL = 1
+ };
+ 
+-#define JV_NUMBER_SIZE_INIT      (0)
+-#define JV_NUMBER_SIZE_CONVERTED (1)
+-
+ #define JVP_FLAGS_NUMBER_NATIVE       JVP_MAKE_FLAGS(JV_KIND_NUMBER, JVP_MAKE_PFLAGS(JVP_NUMBER_NATIVE, 0))
+ #define JVP_FLAGS_NUMBER_LITERAL      JVP_MAKE_FLAGS(JV_KIND_NUMBER, JVP_MAKE_PFLAGS(JVP_NUMBER_DECIMAL, 1))
+ 
+@@ -589,8 +586,12 @@ static jv jvp_literal_number_new(const char * literal) {
+     jv_mem_free(n);
+     return JV_INVALID;
+   }
++  if (decNumberIsNaN(&n->num_decimal)) {
++    jv_mem_free(n);
++    return jv_number(NAN);
++  }
+ 
+-  jv r = {JVP_FLAGS_NUMBER_LITERAL, 0, 0, JV_NUMBER_SIZE_INIT, {&n->refcnt}};
++  jv r = {JVP_FLAGS_NUMBER_LITERAL, 0, 0, 0, {&n->refcnt}};
+   return r;
+ }
+ 
+@@ -698,9 +699,8 @@ double jv_number_value(jv j) {
+   if (JVP_HAS_FLAGS(j, JVP_FLAGS_NUMBER_LITERAL)) {
+     jvp_literal_number* n = jvp_literal_number_ptr(j);
+ 
+-    if (j.size != JV_NUMBER_SIZE_CONVERTED) {
++    if (isnan(n->num_double)) {
+       n->num_double = jvp_literal_number_to_double(j);
+-      j.size = JV_NUMBER_SIZE_CONVERTED;
+     }
+ 
+     return n->num_double;
+@@ -731,7 +731,7 @@ int jvp_number_is_nan(jv n) {
+     return decNumberIsNaN(pdec);
+   }
+ #endif
+-  return n.u.number != n.u.number;
++  return isnan(n.u.number);
+ }
+ 
+ int jvp_number_cmp(jv a, jv b) {
+-- 
+2.49.0
+

--- a/pkgs/by-name/jq/jq/0003-Reject-NaN-with-payload-while-parsing-JSON.patch
+++ b/pkgs/by-name/jq/jq/0003-Reject-NaN-with-payload-while-parsing-JSON.patch
@@ -1,7 +1,7 @@
 From dfd25612454deacb6df47329787844795bf59821 Mon Sep 17 00:00:00 2001
 From: itchyny <itchyny@cybozu.co.jp>
 Date: Wed, 5 Mar 2025 07:43:54 +0900
-Subject: [PATCH 3/4] Reject NaN with payload while parsing JSON
+Subject: [PATCH 3/5] Reject NaN with payload while parsing JSON
 
 This commit drops support for parsing NaN with payload in JSON like
 `NaN123` and fixes CVE-2024-53427. Other JSON extensions like `NaN` and

--- a/pkgs/by-name/jq/jq/0003-Reject-NaN-with-payload-while-parsing-JSON.patch
+++ b/pkgs/by-name/jq/jq/0003-Reject-NaN-with-payload-while-parsing-JSON.patch
@@ -1,0 +1,75 @@
+From dfd25612454deacb6df47329787844795bf59821 Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Wed, 5 Mar 2025 07:43:54 +0900
+Subject: [PATCH 3/4] Reject NaN with payload while parsing JSON
+
+This commit drops support for parsing NaN with payload in JSON like
+`NaN123` and fixes CVE-2024-53427. Other JSON extensions like `NaN` and
+`Infinity` are still supported. Fixes #3023, fixes #3196, fixes #3246.
+---
+ src/jv.c      |  5 +++++
+ tests/jq.test | 14 ++++++++++----
+ tests/shtest  |  5 -----
+ 3 files changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/src/jv.c b/src/jv.c
+index 418d57d..6147775 100644
+--- a/src/jv.c
++++ b/src/jv.c
+@@ -587,6 +587,11 @@ static jv jvp_literal_number_new(const char * literal) {
+     return JV_INVALID;
+   }
+   if (decNumberIsNaN(&n->num_decimal)) {
++    // Reject NaN with payload.
++    if (n->num_decimal.digits > 1 || *n->num_decimal.lsu != 0) {
++      jv_mem_free(n);
++      return JV_INVALID;
++    }
+     jv_mem_free(n);
+     return jv_number(NAN);
+   }
+diff --git a/tests/jq.test b/tests/jq.test
+index e82cf84..97835f2 100644
+--- a/tests/jq.test
++++ b/tests/jq.test
+@@ -1950,11 +1950,17 @@ tojson | fromjson
+ {"a":nan}
+ {"a":null}
+ 
+-# also "nan with payload" #2985
+-fromjson | isnan
+-"nan1234"
++# NaN with payload is not parsed
++.[] | try (fromjson | isnan) catch .
++["NaN","-NaN","NaN1","NaN10","NaN100","NaN1000","NaN10000","NaN100000"]
+ true
+-
++true
++"Invalid numeric literal at EOF at line 1, column 4 (while parsing 'NaN1')"
++"Invalid numeric literal at EOF at line 1, column 5 (while parsing 'NaN10')"
++"Invalid numeric literal at EOF at line 1, column 6 (while parsing 'NaN100')"
++"Invalid numeric literal at EOF at line 1, column 7 (while parsing 'NaN1000')"
++"Invalid numeric literal at EOF at line 1, column 8 (while parsing 'NaN10000')"
++"Invalid numeric literal at EOF at line 1, column 9 (while parsing 'NaN100000')"
+ 
+ # calling input/0, or debug/0 in a test doesn't crash jq
+ 
+diff --git a/tests/shtest b/tests/shtest
+index 14aafbf..a471889 100755
+--- a/tests/shtest
++++ b/tests/shtest
+@@ -594,11 +594,6 @@ if ! x=$($JQ -n "1 # foo$cr + 2") || [ "$x" != 1 ]; then
+   exit 1
+ fi
+ 
+-# CVE-2023-50268: No stack overflow comparing a nan with a large payload
+-$VALGRIND $Q $JQ '1 != .' <<\EOF >/dev/null
+-Nan4000
+-EOF
+-
+ # Allow passing the inline jq script before -- #2919
+ if ! r=$($JQ --args -rn -- '$ARGS.positional[0]' bar) || [ "$r" != bar ]; then
+     echo "passing the inline script after -- didn't work"
+-- 
+2.49.0
+

--- a/pkgs/by-name/jq/jq/0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
+++ b/pkgs/by-name/jq/jq/0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
@@ -1,0 +1,215 @@
+From dc65d5af447f266d8a4037551e028785aab31e04 Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Wed, 21 May 2025 07:45:00 +0900
+Subject: [PATCH 4/4] Fix signed integer overflow in jvp_array_write and
+ jvp_object_rehash
+
+This commit fixes signed integer overflow and SEGV issues on growing
+arrays and objects. The size of arrays and objects is now limited to
+`536870912` (`0x20000000`). This fixes CVE-2024-23337 and fixes #3262.
+---
+ src/jv.c      | 45 ++++++++++++++++++++++++++++++++++++---------
+ src/jv_aux.c  |  9 +++++----
+ tests/jq.test |  4 ++++
+ 3 files changed, 45 insertions(+), 13 deletions(-)
+
+diff --git a/src/jv.c b/src/jv.c
+index 6147775..6e8cdd3 100644
+--- a/src/jv.c
++++ b/src/jv.c
+@@ -997,6 +997,11 @@ jv jv_array_set(jv j, int idx, jv val) {
+     jv_free(val);
+     return jv_invalid_with_msg(jv_string("Out of bounds negative array index"));
+   }
++  if (idx > (INT_MAX >> 2) - jvp_array_offset(j)) {
++    jv_free(j);
++    jv_free(val);
++    return jv_invalid_with_msg(jv_string("Array index too large"));
++  }
+   // copy/free of val,j coalesced
+   jv* slot = jvp_array_write(&j, idx);
+   jv_free(*slot);
+@@ -1016,6 +1021,7 @@ jv jv_array_concat(jv a, jv b) {
+   // FIXME: could be faster
+   jv_array_foreach(b, i, elem) {
+     a = jv_array_append(a, elem);
++    if (!jv_is_valid(a)) break;
+   }
+   jv_free(b);
+   return a;
+@@ -1288,6 +1294,7 @@ jv jv_string_indexes(jv j, jv k) {
+     p = jstr;
+     while ((p = _jq_memmem(p, (jstr + jlen) - p, idxstr, idxlen)) != NULL) {
+       a = jv_array_append(a, jv_number(p - jstr));
++      if (!jv_is_valid(a)) break;
+       p++;
+     }
+   }
+@@ -1336,14 +1343,17 @@ jv jv_string_split(jv j, jv sep) {
+ 
+   if (seplen == 0) {
+     int c;
+-    while ((jstr = jvp_utf8_next(jstr, jend, &c)))
++    while ((jstr = jvp_utf8_next(jstr, jend, &c))) {
+       a = jv_array_append(a, jv_string_append_codepoint(jv_string(""), c));
++      if (!jv_is_valid(a)) break;
++    }
+   } else {
+     for (p = jstr; p < jend; p = s + seplen) {
+       s = _jq_memmem(p, jend - p, sepstr, seplen);
+       if (s == NULL)
+         s = jend;
+       a = jv_array_append(a, jv_string_sized(p, s - p));
++      if (!jv_is_valid(a)) break;
+       // Add an empty string to denote that j ends on a sep
+       if (s + seplen == jend && seplen != 0)
+         a = jv_array_append(a, jv_string(""));
+@@ -1361,8 +1371,10 @@ jv jv_string_explode(jv j) {
+   const char* end = i + len;
+   jv a = jv_array_sized(len);
+   int c;
+-  while ((i = jvp_utf8_next(i, end, &c)))
++  while ((i = jvp_utf8_next(i, end, &c))) {
+     a = jv_array_append(a, jv_number(c));
++    if (!jv_is_valid(a)) break;
++  }
+   jv_free(j);
+   return a;
+ }
+@@ -1636,10 +1648,13 @@ static void jvp_object_free(jv o) {
+   }
+ }
+ 
+-static jv jvp_object_rehash(jv object) {
++static int jvp_object_rehash(jv *objectp) {
++  jv object = *objectp;
+   assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
+   assert(jvp_refcnt_unshared(object.u.ptr));
+   int size = jvp_object_size(object);
++  if (size > INT_MAX >> 2)
++    return 0;
+   jv new_object = jvp_object_new(size * 2);
+   for (int i=0; i<size; i++) {
+     struct object_slot* slot = jvp_object_get_slot(object, i);
+@@ -1652,7 +1667,8 @@ static jv jvp_object_rehash(jv object) {
+   }
+   // references are transported, just drop the old table
+   jv_mem_free(jvp_object_ptr(object));
+-  return new_object;
++  *objectp = new_object;
++  return 1;
+ }
+ 
+ static jv jvp_object_unshare(jv object) {
+@@ -1681,27 +1697,32 @@ static jv jvp_object_unshare(jv object) {
+   return new_object;
+ }
+ 
+-static jv* jvp_object_write(jv* object, jv key) {
++static int jvp_object_write(jv* object, jv key, jv **valpp) {
+   *object = jvp_object_unshare(*object);
+   int* bucket = jvp_object_find_bucket(*object, key);
+   struct object_slot* slot = jvp_object_find_slot(*object, key, bucket);
+   if (slot) {
+     // already has the key
+     jvp_string_free(key);
+-    return &slot->value;
++    *valpp = &slot->value;
++    return 1;
+   }
+   slot = jvp_object_add_slot(*object, key, bucket);
+   if (slot) {
+     slot->value = jv_invalid();
+   } else {
+-    *object = jvp_object_rehash(*object);
++    if (!jvp_object_rehash(object)) {
++      *valpp = NULL;
++      return 0;
++    }
+     bucket = jvp_object_find_bucket(*object, key);
+     assert(!jvp_object_find_slot(*object, key, bucket));
+     slot = jvp_object_add_slot(*object, key, bucket);
+     assert(slot);
+     slot->value = jv_invalid();
+   }
+-  return &slot->value;
++  *valpp = &slot->value;
++  return 1;
+ }
+ 
+ static int jvp_object_delete(jv* object, jv key) {
+@@ -1801,7 +1822,11 @@ jv jv_object_set(jv object, jv key, jv value) {
+   assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
+   assert(JVP_HAS_KIND(key, JV_KIND_STRING));
+   // copy/free of object, key, value coalesced
+-  jv* slot = jvp_object_write(&object, key);
++  jv* slot;
++  if (!jvp_object_write(&object, key, &slot)) {
++    jv_free(object);
++    return jv_invalid_with_msg(jv_string("Object too big"));
++  }
+   jv_free(*slot);
+   *slot = value;
+   return object;
+@@ -1826,6 +1851,7 @@ jv jv_object_merge(jv a, jv b) {
+   assert(JVP_HAS_KIND(a, JV_KIND_OBJECT));
+   jv_object_foreach(b, k, v) {
+     a = jv_object_set(a, k, v);
++    if (!jv_is_valid(a)) break;
+   }
+   jv_free(b);
+   return a;
+@@ -1845,6 +1871,7 @@ jv jv_object_merge_recursive(jv a, jv b) {
+       jv_free(elem);
+       a = jv_object_set(a, k, v);
+     }
++    if (!jv_is_valid(a)) break;
+   }
+   jv_free(b);
+   return a;
+diff --git a/src/jv_aux.c b/src/jv_aux.c
+index 6004799..bbe1c0d 100644
+--- a/src/jv_aux.c
++++ b/src/jv_aux.c
+@@ -193,18 +193,19 @@ jv jv_set(jv t, jv k, jv v) {
+         if (slice_len < insert_len) {
+           // array is growing
+           int shift = insert_len - slice_len;
+-          for (int i = array_len - 1; i >= end; i--) {
++          for (int i = array_len - 1; i >= end && jv_is_valid(t); i--) {
+             t = jv_array_set(t, i + shift, jv_array_get(jv_copy(t), i));
+           }
+         } else if (slice_len > insert_len) {
+           // array is shrinking
+           int shift = slice_len - insert_len;
+-          for (int i = end; i < array_len; i++) {
++          for (int i = end; i < array_len && jv_is_valid(t); i++) {
+             t = jv_array_set(t, i - shift, jv_array_get(jv_copy(t), i));
+           }
+-          t = jv_array_slice(t, 0, array_len - shift);
++          if (jv_is_valid(t))
++            t = jv_array_slice(t, 0, array_len - shift);
+         }
+-        for (int i=0; i < insert_len; i++) {
++        for (int i = 0; i < insert_len && jv_is_valid(t); i++) {
+           t = jv_array_set(t, start + i, jv_array_get(jv_copy(v), i));
+         }
+         jv_free(v);
+diff --git a/tests/jq.test b/tests/jq.test
+index 97835f2..10b20e3 100644
+--- a/tests/jq.test
++++ b/tests/jq.test
+@@ -198,6 +198,10 @@ null
+ [0,1,2]
+ [0,5,2]
+ 
++try (.[999999999] = 0) catch .
++null
++"Array index too large"
++
+ #
+ # Multiple outputs, iteration
+ #
+-- 
+2.49.0
+

--- a/pkgs/by-name/jq/jq/0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
+++ b/pkgs/by-name/jq/jq/0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
@@ -1,7 +1,7 @@
 From dc65d5af447f266d8a4037551e028785aab31e04 Mon Sep 17 00:00:00 2001
 From: itchyny <itchyny@cybozu.co.jp>
 Date: Wed, 21 May 2025 07:45:00 +0900
-Subject: [PATCH 4/4] Fix signed integer overflow in jvp_array_write and
+Subject: [PATCH 4/5] Fix signed integer overflow in jvp_array_write and
  jvp_object_rehash
 
 This commit fixes signed integer overflow and SEGV issues on growing

--- a/pkgs/by-name/jq/jq/0005-Fix-heap-buffer-overflow-when-formatting-an-empty-st.patch
+++ b/pkgs/by-name/jq/jq/0005-Fix-heap-buffer-overflow-when-formatting-an-empty-st.patch
@@ -1,0 +1,45 @@
+From d73a79035e1d24011a3363d52bf36b4eaea67aa6 Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Sat, 31 May 2025 11:46:40 +0900
+Subject: [PATCH 5/5] Fix heap buffer overflow when formatting an empty string
+
+The `jv_string_empty` did not properly null-terminate the string data,
+which could lead to a heap buffer overflow. The test case of
+GHSA-p7rr-28xf-3m5w (`0[""*0]`) was fixed by the commit dc849e9bb74a,
+but another case (`0[[]|implode]`) was still vulnerable. This commit
+ensures string data is properly null-terminated, and fixes CVE-2025-48060.
+---
+ src/jv.c      | 1 +
+ tests/jq.test | 4 ++++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/src/jv.c b/src/jv.c
+index 6e8cdd3..3303286 100644
+--- a/src/jv.c
++++ b/src/jv.c
+@@ -1121,6 +1121,7 @@ static jv jvp_string_empty_new(uint32_t length) {
+   jvp_string* s = jvp_string_alloc(length);
+   s->length_hashed = 0;
+   memset(s->data, 0, length);
++  s->data[length] = 0;
+   jv r = {JVP_FLAGS_STRING, 0, 0, 0, {&s->refcnt}};
+   return r;
+ }
+diff --git a/tests/jq.test b/tests/jq.test
+index 10b20e3..680706b 100644
+--- a/tests/jq.test
++++ b/tests/jq.test
+@@ -2042,6 +2042,10 @@ map(try implode catch .)
+ [123,["a"],[nan]]
+ ["implode input must be an array","string (\"a\") can't be imploded, unicode codepoint needs to be numeric","number (null) can't be imploded, unicode codepoint needs to be numeric"]
+ 
++try 0[implode] catch .
++[]
++"Cannot index number with string \"\""
++
+ # walk
+ walk(.)
+ {"x":0}
+-- 
+2.49.0
+

--- a/pkgs/by-name/jq/jq/package.nix
+++ b/pkgs/by-name/jq/jq/package.nix
@@ -27,6 +27,25 @@ stdenv.mkDerivation rec {
     "out"
   ];
 
+  patches = [
+    # can't fetchpatch because jq is in bootstrap for darwin
+    # CVE-2025-48060
+    # https://github.com/jqlang/jq/commit/dc849e9bb74a7a164a3ea52f661cc712b1ffbd43
+    ./0001-Improve-performance-of-repeating-strings-3272.patch
+
+    # needed for the other patches to apply correctly
+    # https://github.com/jqlang/jq/commit/b86ff49f46a4a37e5a8e75a140cb5fd6e1331384
+    ./0002-fix-jv_number_value-should-cache-the-double-value-of.patch
+
+    # CVE-2024-53427
+    # https://github.com/jqlang/jq/commit/a09a4dfd55e6c24d04b35062ccfe4509748b1dd3
+    ./0003-Reject-NaN-with-payload-while-parsing-JSON.patch
+
+    # CVE-2024-23337
+    # https://github.com/jqlang/jq/commit/de21386681c0df0104a99d9d09db23a9b2a78b1e
+    ./0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
+  ];
+
   # https://github.com/jqlang/jq/issues/2871
   postPatch = lib.optionalString stdenv.hostPlatform.isFreeBSD ''
     substituteInPlace Makefile.am --replace-fail "tests/mantest" "" --replace-fail "tests/optionaltest" ""

--- a/pkgs/by-name/jq/jq/package.nix
+++ b/pkgs/by-name/jq/jq/package.nix
@@ -44,6 +44,11 @@ stdenv.mkDerivation rec {
     # CVE-2024-23337
     # https://github.com/jqlang/jq/commit/de21386681c0df0104a99d9d09db23a9b2a78b1e
     ./0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
+
+    # CVE-2025-48060, part two
+    # Improve-performance-of-repeating-strings is only a partial fix
+    # https://github.com/jqlang/jq/commit/c6e041699d8cd31b97375a2596217aff2cfca85b
+    ./0005-Fix-heap-buffer-overflow-when-formatting-an-empty-st.patch
   ];
 
   # https://github.com/jqlang/jq/issues/2871


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
